### PR TITLE
Retry initSKey in tick() with exponential backoff on boot failure

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -38,6 +38,11 @@
 #define NEATO_QUEUE_MAX_SIZE 16
 #define NEATO_RESPONSE_TERMINATOR 0x1A // Ctrl-Z
 
+// initSKey retry — GetVersion can fail at boot if the robot is still powering up.
+// Retry with exponential backoff until the robot responds.
+#define SKEY_RETRY_INITIAL_MS 2000 // First retry after 2s
+#define SKEY_RETRY_MAX_MS 30000 // Cap backoff at 30s
+
 // AsyncCache TTL values (milliseconds) — how long each response is considered fresh.
 // Callers within the TTL window get the cached value instantly; concurrent requests
 // during an in-flight fetch are coalesced (only one serial command dispatched).

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -87,10 +87,6 @@ void setup() {
     LOG("BOOT", "Initializing Neato serial...");
     neatoSerial.begin(s.uartTxPin, s.uartRxPin);
 
-    // Compute SetEvent security key from robot serial number (async — runs
-    // once the first GetVersion response arrives from the UART queue).
-    neatoSerial.initSKey();
-
     // Wire WiFi events to data logger BEFORE WiFi connects so boot events are captured.
     // DataLogger buffers entries in memory — they get flushed once LittleFS mounts in begin().
     WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {

--- a/firmware/src/neato_serial.cpp
+++ b/firmware/src/neato_serial.cpp
@@ -51,11 +51,16 @@ void NeatoSerial::begin(int txPin, int rxPin) {
 }
 
 void NeatoSerial::initSKey() {
+    sKeyPending = true;
+    versionCache.invalidate(); // Force a fresh fetch (don't serve a stale failure)
     getVersion([this](bool ok, const VersionData& v) {
         if (!ok || v.serialNumber.length() == 0) {
-            LOG("NEATO", "SKey init failed — GetVersion returned no serial");
+            LOG("NEATO", "SKey init failed — GetVersion returned no serial, retrying in %lu ms", sKeyRetryDelay);
+            sKeyRetryAt = millis() + sKeyRetryDelay;
+            sKeyRetryDelay = (sKeyRetryDelay * 2 < SKEY_RETRY_MAX_MS) ? sKeyRetryDelay * 2 : SKEY_RETRY_MAX_MS;
             return;
         }
+        sKeyPending = false;
         robotModelName = v.modelName;
         LOG("NEATO", "Model: %s (supported=%s)", robotModelName.c_str(),
             isSupportedModel(robotModelName) ? "yes" : "no");
@@ -73,6 +78,15 @@ String NeatoSerial::buildSetEvent(const char *event) const {
 }
 
 void NeatoSerial::tick() {
+    // Drive initSKey lifecycle: first attempt + retries on failure.
+    // Runs inside tick() (not setup()) so the UART state machine is already
+    // processing the queue — avoids the race where GetVersion was enqueued
+    // in setup() but tick() hadn't started yet.
+    if (sKeyPending && millis() >= sKeyRetryAt) {
+        sKeyRetryAt = ULONG_MAX; // Prevent re-entry while fetch is in flight
+        initSKey();
+    }
+
     switch (state) {
         case QUEUE_IDLE:
             if (!queue.empty()) {

--- a/firmware/src/neato_serial.h
+++ b/firmware/src/neato_serial.h
@@ -31,13 +31,17 @@ public:
     void begin(int txPin, int rxPin);
 
     // Fetch GetVersion, extract serial number, and compute the SetEvent SKey.
-    // Must be called after begin(). The SKey is required for all cleaning
-    // control commands (start, stop, pause, resume, dock).
+    // Driven automatically by tick() — first attempt fires on the first loop
+    // iteration, with exponential backoff retries on failure (robot may still
+    // be booting). The SKey is required for all cleaning control commands.
     void initSKey();
     bool hasSKey() const { return sKey.length() > 0; }
 
     // Model name extracted from GetVersion at boot (e.g. "Botvac D7")
     const String& getModelName() const { return robotModelName; }
+
+    // True while initSKey is still retrying (robot not yet identified)
+    bool isIdentifying() const { return sKeyPending; }
 
     // -- Sensor queries (typed callbacks) ------------------------------------
     // These are transparently cached: concurrent requests are coalesced,
@@ -111,6 +115,12 @@ private:
 
     // Robot model name extracted from GetVersion at boot
     String robotModelName;
+
+    // initSKey retry state — retries with exponential backoff if GetVersion
+    // fails at boot (e.g. robot still booting, UART not ready yet).
+    bool sKeyPending = true;
+    unsigned long sKeyRetryAt = 0;
+    unsigned long sKeyRetryDelay = SKEY_RETRY_INITIAL_MS;
 
     // Build a SetEvent command string: "SetEvent event <evt> SKey <sKey>"
     String buildSetEvent(const char *event) const;

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -326,6 +326,7 @@ void WebServer::registerFirmwareRoutes() {
                 {"chip", fwMgr.getChipModel(), FIELD_STRING},
                 {"model", neato.getModelName(), FIELD_STRING},
                 {"supported", isSupportedModel(neato.getModelName()) ? "true" : "false", FIELD_BOOL},
+                {"identifying", neato.isIdentifying() ? "true" : "false", FIELD_BOOL},
         };
         request->send(200, "application/json", fieldsToJson(fields));
         return 200;

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -68,7 +68,8 @@ const _randf = (min, max, decimals = 2) => parseFloat((Math.random() * (max - mi
 //
 // Robot state:
 //   ok   — Idle, battery 85%          off  — Device unreachable
-//   unsup — Unsupported robot model   upd  — Firmware v0.9 (triggers update banner)
+//   ident — Identifying robot (boot)  unsup — Unsupported robot model
+//   upd  — Firmware v0.9 (triggers update banner)
 //   cls  — House cleaning             spt  — Spot cleaning
 //   dock — Docking (return to base)   rchg — Mid-clean recharge (on dock, charging)
 //   chg  — Charging, 62%              ch2  — Charging, 25%
@@ -146,6 +147,7 @@ const SCENARIOS = {
     mbs: { manualClean: true, manualBumperSideRight: true },
     msf: { manualClean: true, manualStallFront: true },
     msr: { manualClean: true, manualStallRear: true },
+    ident: { identifying: true },
     unsup: { unsupported: true },
     upd: { firmwareVersion: "0.9" },
     llq: { lidarLowQuality: true },
@@ -231,6 +233,7 @@ const state = {
     // Mid-clean recharge (docking to charge, then resume)
     midCleanRecharge: false,
     // Robot model
+    identifying: false,
     unsupported: false,
     // Firmware version override (null = auto from git hash)
     firmwareVersion: null,
@@ -705,7 +708,8 @@ const routes = {
         jsonResponse(res, {
             version: state.firmwareVersion ?? getVersion(),
             chip: "ESP32-C3",
-            supported: !state.unsupported,
+            supported: !state.unsupported && !state.identifying,
+            identifying: state.identifying,
         });
     },
 };

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -136,10 +136,23 @@ export function App() {
         setSideBrush(next);
     }, [brush, vacuum, sideBrush]);
 
+    // Show a loading screen while the firmware is still trying to identify the robot
+    // (GetVersion may need multiple retries if the robot is slow to boot).
+    if (!firmware.data || firmware.data.identifying) {
+        return (
+            <div class="unsupported-screen">
+                <div class="unsupported-icon">
+                    <Icon svg={robotSvg} />
+                </div>
+                <p>Connecting to robot...</p>
+            </div>
+        );
+    }
+
     // Block the entire UI if the robot model is unsupported (SKey not computed).
-    // firmware.data?.supported is false when GetVersion returned no usable serial
+    // firmware.data.supported is false when GetVersion returned no usable serial
     // number (e.g. XV-series, D8/D9/D10, or UART not connected).
-    if (firmware.data && !firmware.data.supported) {
+    if (!firmware.data.supported) {
         return (
             <div class="unsupported-screen">
                 <div class="unsupported-icon">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -99,6 +99,7 @@ export interface FirmwareVersion {
     version: string;
     chip: string;
     supported: boolean;
+    identifying: boolean;
 }
 
 export interface ManualStatus {


### PR DESCRIPTION
## Summary

- Move `initSKey()` from `setup()` into `NeatoSerial::tick()` so GetVersion runs inside the active UART state machine instead of being enqueued before the queue starts processing
- Retry with exponential backoff (2s–30s) when GetVersion fails at boot
- Add `identifying` field to `/api/firmware/version` and show "Connecting to robot..." in the frontend while retrying, instead of permanently blocking the UI with "Unsupported Robot"
- Add `ident` mock scenario

Fixes #2