### PR TITLE
Add -version flag to flash tool, fix firmware version in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,8 @@ jobs:
         run: pip install platformio
 
       - name: Build firmware and package release artifacts
+        env:
+          FIRMWARE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           # Build all *-release environments; post-build hook packages
           # firmware artifacts into each env's build dir for GoReleaser

--- a/flash/main.go
+++ b/flash/main.go
@@ -23,6 +23,7 @@ func main() {
 	listPorts := flag.Bool("list", false, "List available serial ports")
 	noMonitor := flag.Bool("no-monitor", false, "Skip serial monitor after flashing")
 	monitorOnly := flag.Bool("monitor", false, "Open serial monitor without flashing")
+	showVersion := flag.Bool("version", false, "Print version and exit")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "openneato-flash - Flash and configure OpenNeato firmware\n\n")
@@ -36,6 +37,11 @@ func main() {
 	}
 
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("openneato-flash %s\n", version)
+		return
+	}
 
 	if *listPorts {
 		ports, err := detectPorts()


### PR DESCRIPTION
## Summary

- Add `-version` CLI flag to the flash tool that prints the version and exits
- Fix release workflow to pass `FIRMWARE_VERSION` env var to PlatformIO build (was falling back to `0.0-<git-hash>` instead of the actual release version)