### PR TITLE
feat: add support for ESP32-S3 boards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [c3-debug, esp32-debug]
+        env: [c3-debug, s3-debug, esp32-debug]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Neato Botvac D3 through D7. D8/D9/D10 are NOT supported (different board, passwo
 
 ### Requirements
 
-- ESP32-C3 or original ESP32 board with **4 MB flash** (any dev board with USB and exposed GPIOs)
+- ESP32-C3, ESP32-S3, or original ESP32 board with **4 MB flash** (any dev board with USB and exposed GPIOs)
 
 ### Quick Start
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -97,9 +97,10 @@ These are the **robot's** RX/TX labels, so you cross-connect to the ESP32:
 | TX        | ESP RX    | Robot sends data to ESP      |
 | GND       | GND       | Common ground                |
 
-The default TX/RX GPIOs depend on the chip (ESP32-C3: GPIO 3/4, original ESP32: GPIO 17/16)
-but are fully configurable from the web UI in **Settings -> Robot -> UART Pins** — so wire
-whichever GPIOs are convenient and update the setting to match.
+The default TX/RX GPIOs depend on the chip (ESP32-C3: GPIO 3/4, ESP32-S3: GPIO 17/18,
+original ESP32: GPIO 17/16) but are fully configurable from the web UI in
+**Settings -> Robot -> UART Pins** — so wire whichever GPIOs are convenient and update the
+setting to match.
 
 ### Wiring
 
@@ -362,7 +363,7 @@ Two ways to factory reset:
 
 1. **From the web UI**: Settings -> Device -> Factory Reset. Type `RESET` to confirm.
 2. **Hardware button**: Hold the BOOT button for 5 seconds (GPIO9 on ESP32-C3, GPIO0 on
-   original ESP32). The ESP32 will erase all settings and restart.
+   ESP32-S3 and original ESP32). The ESP32 will erase all settings and restart.
 
 > [!CAUTION]
 > Both methods erase everything — WiFi credentials, settings, logs, and cleaning history.

--- a/firmware/lib/heatshrink/library.json
+++ b/firmware/lib/heatshrink/library.json
@@ -12,7 +12,8 @@
         ],
         "includeDir": ".",
         "flags": [
-            "-I private"
+            "-I private",
+            "-std=gnu++17"
         ]
     }
 }

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -25,6 +25,7 @@
 // Pin Configuration — boot/reset button and default UART pins vary by chip.
 // Original ESP32: BOOT is GPIO0, GPIO1/3 are the USB-UART bridge (U0TXD/U0RXD).
 // ESP32-C3: BOOT is GPIO9, GPIO1/3 are free GPIOs.
+// ESP32-S3: BOOT is GPIO0, GPIO19/20 are native USB — use free GPIOs for UART.
 #if CONFIG_IDF_TARGET_ESP32
 #define RESET_BUTTON_PIN 0
 #define NEATO_DEFAULT_TX_PIN 17
@@ -35,6 +36,11 @@
 #define NEATO_DEFAULT_TX_PIN 3
 #define NEATO_DEFAULT_RX_PIN 4
 #define MAX_GPIO_PIN 21
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define RESET_BUTTON_PIN 0
+#define NEATO_DEFAULT_TX_PIN 17
+#define NEATO_DEFAULT_RX_PIN 18
+#define MAX_GPIO_PIN 48
 #else
 #error "Unsupported chip — add pin definitions for this target"
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,6 +73,33 @@ build_flags =
     ${board_c3.build_flags}
     -DENABLE_LOGGING=0
 
+; --- Board: ESP32-S3-DevKitC-1 (Xtensa LX7, dual-core, native USB) -----------
+
+[board_s3]
+board = esp32-s3-devkitc-1
+build_flags =
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DCHIP_MODEL=\"ESP32-S3\"
+    -std=gnu++17
+
+; --- Targets (S3) -------------------------------------------------------------
+
+[env:s3-debug]
+extends = board_s3
+
+[env:s3-ota]
+extends = board_s3, mode_ota
+build_flags =
+    ${board_s3.build_flags}
+    -DENABLE_LOGGING=0
+
+[env:s3-release]
+extends = board_s3
+build_flags =
+    ${board_s3.build_flags}
+    -DENABLE_LOGGING=0
+
 ; --- Board: ESP32-D0WD-V3 (original ESP32, Xtensa LX6) ----------------------
 
 [board_esp32]


### PR DESCRIPTION
## Summary

Add build targets, pin definitions, and CI coverage for ESP32-S3 boards.

- Add `[board_s3]` section and `s3-debug`/`s3-ota`/`s3-release` environments in `platformio.ini`
- Add `CONFIG_IDF_TARGET_ESP32S3` pin definitions in `config.h` (BOOT=GPIO0, TX=17, RX=18, MAX_GPIO=48)
- Add `s3-debug` to CI build matrix
- Fix heatshrink S3 SIMD linker error by adding `-std=gnu++17` to library build flags
- Update docs and README to mention S3 support

Closes #12