### PR TITLE
feat: add settings access from unsupported robot screen

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { api } from "./api";
-import alertSvg from "./assets/icons/alert.svg?raw";
-import robotSvg from "./assets/robot.svg?raw";
-import { Icon } from "./components/icon";
 import { Route, Router } from "./components/router";
 import { usePolling } from "./hooks/use-polling";
 import type { FirmwareVersion, ManualStatus, StateData } from "./types";
@@ -136,60 +133,42 @@ export function App() {
         setSideBrush(next);
     }, [brush, vacuum, sideBrush]);
 
-    // Show a loading screen while the firmware is still trying to identify the robot
-    // (GetVersion may need multiple retries if the robot is slow to boot).
-    if (!firmware.data || firmware.data.identifying) {
-        return (
-            <div class="unsupported-screen">
-                <div class="unsupported-icon">
-                    <Icon svg={robotSvg} />
-                </div>
-                <p>Connecting to robot...</p>
-            </div>
-        );
-    }
-
-    // Block the entire UI if the robot model is unsupported (SKey not computed).
-    // firmware.data.supported is false when GetVersion returned no usable serial
-    // number (e.g. XV-series, D8/D9/D10, or UART not connected).
-    if (!firmware.data.supported) {
-        return (
-            <div class="unsupported-screen">
-                <div class="unsupported-icon">
-                    <Icon svg={robotSvg} />
-                </div>
-                <Icon svg={alertSvg} />
-                <h2>Unsupported Robot</h2>
-                <p>
-                    OpenNeato requires a Neato Botvac D3, D4, D5, D6, or D7.
-                    <br />
-                    The connected robot could not be identified.
-                </p>
-            </div>
-        );
-    }
+    // When the robot is still identifying or unsupported, the dashboard shows a
+    // gate message in the hero area with action buttons disabled, but settings,
+    // logs, and other ESP32-only pages remain accessible so the user can fix
+    // UART pins, update firmware, or diagnose the issue (#14).
+    const robotReady = !!(firmware.data && !firmware.data.identifying && firmware.data.supported);
 
     return (
         <Router>
             <Route path="/">
-                <DashboardView firmware={firmware} state={state} isManual={isManual} updateInfo={updateInfo} />
+                <DashboardView
+                    firmware={firmware}
+                    state={state}
+                    isManual={isManual}
+                    updateInfo={updateInfo}
+                    robotReady={robotReady}
+                    identifying={!firmware.data || firmware.data.identifying}
+                />
             </Route>
             <Route path="/settings">
                 <SettingsView theme={theme} onThemeChange={setTheme} firmware={firmware.data} />
             </Route>
-            <Route path="/manual">
-                <ManualView
-                    isManual={isManual}
-                    status={manualStatus.data}
-                    brush={brush}
-                    vacuum={vacuum}
-                    sideBrush={sideBrush}
-                    onToggleBrush={toggleBrush}
-                    onToggleVacuum={toggleVacuum}
-                    onToggleSideBrush={toggleSideBrush}
-                    onToggleAll={toggleAll}
-                />
-            </Route>
+            {robotReady && (
+                <Route path="/manual">
+                    <ManualView
+                        isManual={isManual}
+                        status={manualStatus.data}
+                        brush={brush}
+                        vacuum={vacuum}
+                        sideBrush={sideBrush}
+                        onToggleBrush={toggleBrush}
+                        onToggleVacuum={toggleVacuum}
+                        onToggleSideBrush={toggleSideBrush}
+                        onToggleAll={toggleAll}
+                    />
+                </Route>
+            )}
             <Route path="/schedule">
                 <ScheduleView />
             </Route>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -217,6 +217,11 @@ body {
     transform: scale(0.85);
 }
 
+.header-right-btn:disabled {
+    opacity: 0.3;
+    pointer-events: none;
+}
+
 /* Hero area */
 
 .hero-area {
@@ -244,6 +249,50 @@ body {
     width: 100%;
     height: 100%;
     filter: drop-shadow(1px 0 0 #fff) drop-shadow(-1px 0 0 #fff) drop-shadow(0 1px 0 #fff) drop-shadow(0 -1px 0 #fff);
+}
+
+/* Gate hero — shown when robot is identifying or unsupported */
+
+.gate-hero {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.gate-robot {
+    position: static;
+    width: 120px;
+    height: 120px;
+    opacity: 0.15;
+}
+
+.gate-message {
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.gate-message > span svg {
+    width: 32px;
+    height: 32px;
+    color: var(--amber);
+    margin-bottom: 8px;
+}
+
+.gate-message h2 {
+    margin: 0 0 8px;
+    font-size: 18px;
+    color: var(--text-primary);
+}
+
+.gate-message p {
+    margin: 0;
+    line-height: 1.5;
+    max-width: 320px;
 }
 
 /* Info cards */
@@ -544,49 +593,6 @@ body {
 
 .conn-error span {
     display: flex;
-}
-
-/* Unsupported robot screen */
-
-.unsupported-screen {
-    text-align: center;
-    padding: 40px 24px;
-    color: var(--text-dim);
-    font-size: 14px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 80vh;
-}
-
-.unsupported-screen .unsupported-icon {
-    opacity: 0.15;
-    margin-bottom: 16px;
-}
-
-.unsupported-screen .unsupported-icon span svg {
-    width: 120px;
-    height: 120px;
-}
-
-.unsupported-screen > span svg {
-    width: 32px;
-    height: 32px;
-    color: var(--amber);
-    margin-bottom: 8px;
-}
-
-.unsupported-screen h2 {
-    margin: 0 0 8px;
-    font-size: 18px;
-    color: var(--text-primary);
-}
-
-.unsupported-screen p {
-    margin: 0;
-    line-height: 1.5;
-    max-width: 320px;
 }
 
 /* Settings page */

--- a/frontend/src/views/dashboard.tsx
+++ b/frontend/src/views/dashboard.tsx
@@ -111,9 +111,11 @@ interface DashboardViewProps {
     state: PollResult<StateData>;
     isManual: boolean;
     updateInfo: UpdateInfo | null;
+    robotReady: boolean;
+    identifying: boolean;
 }
 
-export function DashboardView({ firmware, state, isManual, updateInfo }: DashboardViewProps) {
+export function DashboardView({ firmware, state, isManual, updateInfo, robotReady, identifying }: DashboardViewProps) {
     const navigate = useNavigate();
     const charger = usePolling<ChargerData>(api.getCharger, 5000);
     const error = usePolling<ErrorData>(api.getError, 2000);
@@ -209,6 +211,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                         class="header-right-btn"
                         aria-label="Cleaning History"
                         onClick={() => navigate("/history")}
+                        disabled={!robotReady}
                     >
                         <Icon svg={historySvg} />
                     </button>
@@ -277,7 +280,26 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
             <ErrorBannerStack errors={actionErrors} />
 
             {/* Hero area — robot right, cards left */}
-            {offline ? (
+            {!robotReady ? (
+                <div class="hero-area gate-hero">
+                    <div class="robot-float gate-robot">
+                        <Icon svg={robotSvg} />
+                    </div>
+                    {identifying ? (
+                        <p class="gate-message">Connecting to robot...</p>
+                    ) : (
+                        <div class="gate-message">
+                            <Icon svg={alertSvg} />
+                            <h2>Unsupported Robot</h2>
+                            <p>
+                                OpenNeato requires a Neato Botvac D3, D4, D5, D6, or D7.
+                                <br />
+                                The connected robot could not be identified.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            ) : offline ? (
                 <div class="conn-error">
                     <Icon svg={wifiOffSvg} />
                     Unable to reach robot
@@ -334,7 +356,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                                 type="button"
                                 class={`action-btn primary${pending ? " pending" : ""}`}
                                 onClick={() => handleAction(isPaused ? api.cleanHouse : api.cleanPause)}
-                                disabled={offline || pending}
+                                disabled={!robotReady || offline || pending}
                             >
                                 <Icon svg={isPaused ? playSvg : pauseSvg} />
                                 {isPaused ? "Resume" : "Pause"}
@@ -343,7 +365,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                                 type="button"
                                 class={`action-btn${pending ? " pending" : ""}`}
                                 onClick={() => handleAction(api.cleanDock)}
-                                disabled={offline || pending}
+                                disabled={!robotReady || offline || pending}
                             >
                                 <Icon svg={dockSvg} />
                                 Dock
@@ -352,7 +374,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                                 type="button"
                                 class={`action-btn${pending ? " pending" : ""}`}
                                 onClick={() => handleAction(api.cleanStop)}
-                                disabled={offline || pending}
+                                disabled={!robotReady || offline || pending}
                             >
                                 <Icon svg={stopSvg} />
                                 Stop
@@ -365,7 +387,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                                 type="button"
                                 class={`action-btn primary${pending ? " pending" : ""}`}
                                 onClick={() => handleAction(api.cleanHouse)}
-                                disabled={offline || isDocking || isManual || pending || hasRobotError}
+                                disabled={!robotReady || offline || isDocking || isManual || pending || hasRobotError}
                             >
                                 <Icon svg={houseSvg} />
                                 House
@@ -374,7 +396,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                                 type="button"
                                 class={`action-btn${pending ? " pending" : ""}`}
                                 onClick={() => handleAction(api.cleanSpot)}
-                                disabled={offline || isDocking || isManual || pending || hasRobotError}
+                                disabled={!robotReady || offline || isDocking || isManual || pending || hasRobotError}
                             >
                                 <Icon svg={spotSvg} />
                                 Spot
@@ -393,7 +415,10 @@ export function DashboardView({ firmware, state, isManual, updateInfo }: Dashboa
                                             })
                                 }
                                 disabled={
-                                    offline || (pending && !isManual) || (hasRobotError && !isManual && !isDocking)
+                                    !robotReady ||
+                                    offline ||
+                                    (pending && !isManual) ||
+                                    (hasRobotError && !isManual && !isDocking)
                                 }
                             >
                                 <Icon svg={isDocking ? stopSvg : manualSvg} />


### PR DESCRIPTION
## Summary

- Replace full-screen gate with inline hero message, keeping the dashboard layout intact
- Settings gear button remains active; history button and action buttons are disabled
- All settings are ESP32-only (NVS/OTA) so they work without a robot connection

Closes #14