### PR TITLE
Add robot power control (restart and shutdown) in settings

### DIFF
--- a/firmware/src/neato_commands.h
+++ b/firmware/src/neato_commands.h
@@ -41,6 +41,8 @@
 #define EVT_STOP "UIMGR_EVENT_SMARTAPP_STOP_CLEANING"
 #define EVT_SEND_TO_BASE "UIMGR_EVENT_SMARTAPP_SEND_TO_BASE"
 #define CMD_SET_MOTOR "SetMotor"
+#define CMD_SET_SYSTEM_MODE_POWER_CYCLE "SetSystemMode PowerCycle"
+#define CMD_SET_SYSTEM_MODE_SHUTDOWN "SetSystemMode Shutdown"
 #define CMD_GET_ROBOT_POS_RAW "GetRobotPos Raw"
 #define CMD_GET_ROBOT_POS_SMOOTH "GetRobotPos Smooth"
 

--- a/firmware/src/neato_serial.cpp
+++ b/firmware/src/neato_serial.cpp
@@ -615,6 +615,36 @@ bool NeatoSerial::setMotorSideBrush(bool on, int powerMw, std::function<void(boo
             PRIORITY_MEDIUM);
 }
 
+// -- Power control -----------------------------------------------------------
+
+bool NeatoSerial::powerControl(const String& action, std::function<void(bool)> callback) {
+    const char *cmd;
+    if (action == "restart") {
+        cmd = CMD_SET_SYSTEM_MODE_POWER_CYCLE;
+    } else if (action == "shutdown") {
+        cmd = CMD_SET_SYSTEM_MODE_SHUTDOWN;
+    } else {
+        LOG("NEATO", "powerControl: unknown action '%s'", action.c_str());
+        if (callback)
+            callback(false);
+        return false;
+    }
+
+    // SetSystemMode requires TestMode On first (protocol specifies 100ms delay,
+    // which the inter-command delay covers). Chain: TestMode On -> SetSystemMode.
+    invalidateState();
+    const char *sysCmd = cmd; // capture for lambda
+    return testMode(true, [this, sysCmd, callback](bool ok) {
+        if (!ok) {
+            LOG("NEATO", "powerControl: TestMode On failed");
+            if (callback)
+                callback(false);
+            return;
+        }
+        enqueue(sysCmd, wrapAction(callback), PRIORITY_HIGH);
+    });
+}
+
 // -- Time commands -----------------------------------------------------------
 
 bool NeatoSerial::getTime(std::function<void(bool, const TimeData&)> callback) {

--- a/firmware/src/neato_serial.h
+++ b/firmware/src/neato_serial.h
@@ -70,6 +70,10 @@ public:
     bool setMotorSideBrush(bool on, int powerMw = 5000, std::function<void(bool)> callback = nullptr);
     bool setTime(int dayOfWeek, int hour, int min, int sec, std::function<void(bool)> callback = nullptr);
 
+    // Power control: sends TestMode On, then SetSystemMode after inter-command delay.
+    // action = "restart" (PowerCycle) or "shutdown" (Shutdown).
+    bool powerControl(const String& action, std::function<void(bool)> callback = nullptr);
+
     // -- Raw command (temporary debug endpoint) --------------------------------
     bool sendRaw(const String& cmd, std::function<void(bool, const String&)> callback);
 

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -95,6 +95,7 @@ void WebServer::registerApiRoutes() {
     registerPostRoute("/api/clean", neato, &NeatoSerial::clean, {"action"});
     registerPostRoute("/api/sound", neato, &NeatoSerial::playSound, {"id"});
     registerPostRoute("/api/testmode", neato, &NeatoSerial::testMode, {"enable"});
+    registerPostRoute("/api/power", neato, &NeatoSerial::powerControl, {"action"});
     registerPostRoute("/api/lidar/rotate", neato, &NeatoSerial::setLdsRotation, {"enable"});
 
     // Debug serial endpoint — send arbitrary serial command, returns raw response.

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -575,6 +575,21 @@ const routes = {
         setTimeout(() => sendOk(res), 600);
     },
 
+    "POST /api/power": (_req, res, query) => {
+        if (faults.actions) return sendError(res, "UART timeout: robot not responding", 500);
+        const action = query.action;
+        if (action === "restart") {
+            // Simulate robot power cycle — robot recovers in ~1s, ESP32 stays online
+            sendOk(res);
+        } else if (action === "shutdown") {
+            // Simulate real ESP32 power loss — respond then kill the dev server
+            sendOk(res);
+            setTimeout(() => process.exit(0), 500);
+        } else {
+            sendError(res, "unknown action", 400);
+        }
+    },
+
     "POST /api/sound": (_req, res) => {
         // Accept and ignore — just acknowledge
         sendOk(res);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -119,6 +119,8 @@ export const api = {
     updateSettings: (patch: Partial<SettingsData>) => put<SettingsData>("/api/settings", patch),
     testNotification: (topic: string) => post(`/api/notifications/test?topic=${encodeURIComponent(topic)}`),
     playSound: (id: number) => post(`/api/sound?id=${id}`),
+    robotRestart: () => post("/api/power?action=restart"),
+    robotShutdown: () => post("/api/power?action=shutdown"),
     restart: () => post("/api/system/restart"),
     formatFs: () => post("/api/system/format-fs"),
     factoryReset: () => post("/api/system/reset"),

--- a/frontend/src/views/dashboard.tsx
+++ b/frontend/src/views/dashboard.tsx
@@ -274,7 +274,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo, robotRead
             {robotError && (
                 <ErrorBanner title={robotError.title} message={robotError.message} variant={robotError.kind} />
             )}
-            {!error.data && error.error && <ErrorBanner title="Warning" message={error.error} />}
+            {!error.data && error.error && !connErr && <ErrorBanner title="Warning" message={error.error} />}
 
             {/* Action errors — dismissible, stackable */}
             <ErrorBannerStack errors={actionErrors} />

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -128,6 +128,62 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
     const [restarting, setRestarting] = useState(false);
     const pendingNav = useRef<string | null>(null);
 
+    // --- Robot power control ---
+    const [showRobotShutdownConfirm, setShowRobotShutdownConfirm] = useState(false);
+    const [robotRestarting, setRobotRestarting] = useState(false);
+    const robotRestartPollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const robotRestartTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (robotRestartPollTimer.current) clearTimeout(robotRestartPollTimer.current);
+            if (robotRestartTimeout.current) clearTimeout(robotRestartTimeout.current);
+        };
+    }, []);
+
+    const handleRobotRestart = useCallback(() => {
+        setRobotRestarting(true);
+
+        robotRestartTimeout.current = setTimeout(() => {
+            if (robotRestartPollTimer.current) clearTimeout(robotRestartPollTimer.current);
+            robotRestartPollTimer.current = null;
+            robotRestartTimeout.current = null;
+            setRobotRestarting(false);
+            errorStack.push("Robot did not recover after restart — check physical connection");
+        }, 30000);
+
+        api.robotRestart()
+            .then(() => {
+                const poll = () => {
+                    api.getState()
+                        .then(() => {
+                            if (robotRestartTimeout.current) clearTimeout(robotRestartTimeout.current);
+                            robotRestartTimeout.current = null;
+                            robotRestartPollTimer.current = null;
+                            setRobotRestarting(false);
+                        })
+                        .catch(() => {
+                            robotRestartPollTimer.current = setTimeout(poll, 2000);
+                        });
+                };
+                robotRestartPollTimer.current = setTimeout(poll, 2000);
+            })
+            .catch((e: unknown) => {
+                if (robotRestartTimeout.current) clearTimeout(robotRestartTimeout.current);
+                robotRestartTimeout.current = null;
+                setRobotRestarting(false);
+                errorStack.push(e instanceof Error ? e.message : "Failed to restart robot");
+            });
+    }, [errorStack]);
+
+    const handleRobotShutdown = useCallback(() => {
+        setShowRobotShutdownConfirm(false);
+        // Navigate immediately — the ESP32 will lose power and go offline,
+        // so we don't wait for the response or surface network errors.
+        api.robotShutdown().catch(() => {});
+        navigate("/");
+    }, [navigate]);
+
     // --- Unsaved changes guards ---
 
     const dirtyRef = useRef(false);
@@ -718,6 +774,29 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     {saveLabel}
                 </button>
 
+                <SettingsCategory title="Robot Power" icon={robotSvg}>
+                    <div class="settings-section">
+                        <button type="button" class="settings-nav-row" onClick={handleRobotRestart}>
+                            <div class="settings-nav-row-left">
+                                <Icon svg={powerSvg} />
+                                Restart Robot
+                            </div>
+                        </button>
+                    </div>
+                    <div class="settings-section">
+                        <button
+                            type="button"
+                            class="settings-nav-row danger"
+                            onClick={() => setShowRobotShutdownConfirm(true)}
+                        >
+                            <div class="settings-nav-row-left">
+                                <Icon svg={alertSvg} />
+                                Shutdown Robot
+                            </div>
+                        </button>
+                    </div>
+                </SettingsCategory>
+
                 <SettingsCategory title="Device" icon={powerSvg}>
                     <div class="settings-section">
                         <button type="button" class="settings-nav-row" onClick={() => setShowRestartConfirm(true)}>
@@ -812,12 +891,25 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                 />
             )}
 
-            {rebooting && (
+            {showRobotShutdownConfirm && (
+                <ConfirmDialog
+                    message="Shut down the robot? The ESP32 will lose power and go offline. The robot needs a physical button press to turn back on."
+                    confirmLabel="Shutdown"
+                    onConfirm={handleRobotShutdown}
+                    onCancel={() => setShowRobotShutdownConfirm(false)}
+                />
+            )}
+
+            {(rebooting || robotRestarting) && (
                 <div class="reboot-overlay">
                     <div class="reboot-dialog">
                         <div class="reboot-spinner" />
-                        <div class="reboot-text">Rebooting...</div>
-                        <div class="reboot-subtext">Waiting for device to come back online</div>
+                        <div class="reboot-text">{robotRestarting ? "Restarting robot..." : "Rebooting..."}</div>
+                        <div class="reboot-subtext">
+                            {robotRestarting
+                                ? "Waiting for robot to come back online"
+                                : "Waiting for device to come back online"}
+                        </div>
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary

- Add `POST /api/power?action=restart|shutdown` endpoint using `SetSystemMode` serial commands
- Add "Robot Power" section in settings with restart and shutdown actions
- Suppress error poll warning banner when connection is already down

Closes #10