### PR TITLE
feat: expose robot user settings in settings page

### DIFF
--- a/docs/neato-serial-protocol.md
+++ b/docs/neato-serial-protocol.md
@@ -84,6 +84,22 @@ Robot GND -> ESP GND. The robot provides 3.3V to power the ESP.
 - `GetSysLog` — System log data (unimplemented in XV-11)
 - `GetWarranty` — Warranty validation codes (hex values)
 - `PlaySound [SoundID N] [Stop]` — Play sound (0-20, see manual for IDs)
+- `GetUserSettings` — Get all user-configurable settings (sound, cleaning, power saving, maintenance)
+- `SetUserSettings [Key ON|OFF|Value]` — Set user settings
+  - `ButtonClick ON/OFF` — Button press sounds
+  - `Melodies ON/OFF` — Startup/shutdown melodies
+  - `Warnings ON/OFF` — Warning beeps
+  - `EcoMode ON/OFF` — Eco cleaning mode (lower brush/vacuum power)
+  - `IntenseClean ON/OFF` — Intense clean (double-pass)
+  - `BinFullDetect ON/OFF` — Dust bin full detection
+  - `WiFi ON/OFF` — Robot's own WiFi radio (unused with OpenNeato)
+  - `StealthLED ON/OFF` — Standby LEDs (ON = hidden, OFF = visible)
+  - `FilterChange <seconds>` — Filter change alert interval
+  - `BrushChange <seconds>` — Brush change alert interval
+  - `DirtBin <minutes>` — Dirt bin alert reminder interval
+  - `Reset` — Reset all user settings to factory defaults
+  - Note: `GetUserSettings` response uses different label names than `SetUserSettings` parameters
+    (e.g. "ClickSounds" vs "ButtonClick", "Melody Sounds" vs "Melodies")
 - `RestoreDefaults` — Restore user settings to default
 - `SetDistanceCal [DropMinimum|DropMiddle|DropMaximum] [WallMinimum|WallMiddle|WallMaximum]` — Set distance sensor calibration values for min and max distances
   - DropMinimum: Take minimum distance drop sensor readings (mutually exclusive of DropMiddle and DropMax)
@@ -262,6 +278,29 @@ Robot GND -> ESP GND. The robot provides 3.3V to power the ESP.
 - **No WiFi control commands** — robot WiFi is managed internally, no serial access
 
 ## Response Formats
+
+**GetUserSettings** — CSV: `Label, Value` (note space after comma)
+```
+Language, EL_NONE
+ClickSounds, OFF
+LED, ON
+Wall Enable, ON
+Eco Mode, ON
+IntenseClean, OFF
+WiFi, ON
+Melody Sounds, OFF
+Warning Sounds, ON
+Bin Full Detect, ON
+Filter Change Time (seconds), 43200
+Brush Change Time (seconds), 259200
+Dirt Bin Alert Reminder Interval (minutes), 90
+Current Dirt Bin Runtime is: 5857220
+Number of Cleanings where Dust Bin was Full is: 1
+Schedule is Disabled
+```
+Note: Labels differ from `SetUserSettings` parameter names (e.g. "ClickSounds" in
+response vs "ButtonClick" in set command, "LED" vs "StealthLED"). LED=ON means
+LEDs are visible (not stealth); StealthLED=ON means LEDs are hidden (stealth mode).
 
 **GetCharger** — CSV: `Label,Value`
 ```

--- a/firmware/src/neato_commands.cpp
+++ b/firmware/src/neato_commands.cpp
@@ -530,6 +530,125 @@ bool parseTimeData(const String& raw, TimeData& out) {
     return true;
 }
 
+// -- User settings -----------------------------------------------------------
+
+std::vector<Field> UserSettingsData::toFields() const {
+    return {
+            {"buttonClick", buttonClick ? "true" : "false", FIELD_BOOL},
+            {"melodies", melodies ? "true" : "false", FIELD_BOOL},
+            {"warnings", warnings ? "true" : "false", FIELD_BOOL},
+            {"ecoMode", ecoMode ? "true" : "false", FIELD_BOOL},
+            {"intenseClean", intenseClean ? "true" : "false", FIELD_BOOL},
+            {"binFullDetect", binFullDetect ? "true" : "false", FIELD_BOOL},
+            {"wifi", wifi ? "true" : "false", FIELD_BOOL},
+            {"stealthLed", stealthLed ? "true" : "false", FIELD_BOOL},
+            {"filterChange", String(filterChange), FIELD_INT},
+            {"brushChange", String(brushChange), FIELD_INT},
+            {"dirtBin", String(dirtBin), FIELD_INT},
+    };
+}
+
+bool UserSettingsData::fromFields(const std::vector<Field>& fields) {
+    bool applied = false;
+    const Field *f;
+    if ((f = findField(fields, "buttonClick"))) {
+        buttonClick = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "melodies"))) {
+        melodies = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "warnings"))) {
+        warnings = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "ecoMode"))) {
+        ecoMode = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "intenseClean"))) {
+        intenseClean = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "binFullDetect"))) {
+        binFullDetect = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "wifi"))) {
+        wifi = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "stealthLed"))) {
+        stealthLed = f->value == "true";
+        applied = true;
+    }
+    if ((f = findField(fields, "filterChange"))) {
+        filterChange = f->value.toInt();
+        applied = true;
+    }
+    if ((f = findField(fields, "brushChange"))) {
+        brushChange = f->value.toInt();
+        applied = true;
+    }
+    if ((f = findField(fields, "dirtBin"))) {
+        dirtBin = f->value.toInt();
+        applied = true;
+    }
+    return applied;
+}
+
+// GetUserSettings response format: "Label, Value\r\n" pairs (note space after comma).
+// Labels use descriptive names with spaces, e.g. "ClickSounds, OFF", "Eco Mode, ON",
+// "Filter Change Time (seconds), 43200". The findCsvValue helper matches the label
+// prefix before the first comma, so we match the exact label strings from the robot.
+bool parseUserSettingsData(const String& raw, UserSettingsData& out) {
+    String val;
+    bool found = false;
+    if (findCsvValue(raw, "ClickSounds", val)) {
+        out.buttonClick = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "Melody Sounds", val)) {
+        out.melodies = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "Warning Sounds", val)) {
+        out.warnings = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "Eco Mode", val)) {
+        out.ecoMode = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "IntenseClean", val)) {
+        out.intenseClean = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "Bin Full Detect", val)) {
+        out.binFullDetect = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "WiFi", val)) {
+        out.wifi = val.equalsIgnoreCase("ON");
+        found = true;
+    }
+    if (findCsvValue(raw, "LED", val)) {
+        // "LED" controls standby indicator lights (StealthLED in Neato app terms).
+        // ON = LEDs visible (not stealth), OFF = LEDs hidden (stealth mode).
+        // We invert: stealthLed=true means LEDs are off.
+        out.stealthLed = val.equalsIgnoreCase("OFF");
+        found = true;
+    }
+    if (findCsvValue(raw, "Filter Change Time (seconds)", val))
+        out.filterChange = val.toInt();
+    if (findCsvValue(raw, "Brush Change Time (seconds)", val))
+        out.brushChange = val.toInt();
+    if (findCsvValue(raw, "Dirt Bin Alert Reminder Interval (minutes)", val))
+        out.dirtBin = val.toInt();
+    return found;
+}
+
 // -- Robot position ----------------------------------------------------------
 
 std::vector<Field> RobotPosData::toFields() const {

--- a/firmware/src/neato_commands.h
+++ b/firmware/src/neato_commands.h
@@ -45,6 +45,8 @@
 #define CMD_SET_SYSTEM_MODE_SHUTDOWN "SetSystemMode Shutdown"
 #define CMD_GET_ROBOT_POS_RAW "GetRobotPos Raw"
 #define CMD_GET_ROBOT_POS_SMOOTH "GetRobotPos Smooth"
+#define CMD_GET_USER_SETTINGS "GetUserSettings"
+#define CMD_SET_USER_SETTINGS "SetUserSettings"
 
 // -- Sound IDs ---------------------------------------------------------------
 
@@ -181,6 +183,29 @@ struct LdsScanData {
     String toJson() const;
 };
 
+// Robot user settings — read via GetUserSettings, write via SetUserSettings.
+// Boolean flags are ON/OFF; interval fields are in seconds or minutes.
+struct UserSettingsData : public JsonSerializable {
+    // Sound control
+    bool buttonClick = true;
+    bool melodies = true;
+    bool warnings = true;
+    // Cleaning behavior
+    bool ecoMode = false;
+    bool intenseClean = false;
+    bool binFullDetect = true;
+    // Power saving
+    bool wifi = true;
+    bool stealthLed = false;
+    // Maintenance reminders (seconds for filter/brush, minutes for dirt bin)
+    int filterChange = 2592000; // 30 days
+    int brushChange = 2592000; // 30 days
+    int dirtBin = 30; // 30 minutes
+
+    std::vector<Field> toFields() const override;
+    bool fromFields(const std::vector<Field>& fields) override;
+};
+
 // Robot position — hidden command, response format unknown.
 // Returns the raw response verbatim for inspection on real hardware.
 struct RobotPosData : public JsonSerializable {
@@ -200,6 +225,7 @@ bool parseErrorData(const String& raw, ErrorData& out);
 bool parseLdsScanData(const String& raw, LdsScanData& out);
 bool parseTimeData(const String& raw, TimeData& out);
 bool parseRobotPosData(const String& raw, RobotPosData& out);
+bool parseUserSettingsData(const String& raw, UserSettingsData& out);
 
 // -- Model support -----------------------------------------------------------
 // Checks if the parsed model name matches a supported Botvac (D3-D7).

--- a/firmware/src/neato_serial.cpp
+++ b/firmware/src/neato_serial.cpp
@@ -38,7 +38,10 @@ NeatoSerial::NeatoSerial() :
     robotPosSmoothCache(
             CACHE_TTL_SENSORS,
             [this](AsyncCache<RobotPosData>::Callback cb) { fetchRobotPos(CMD_GET_ROBOT_POS_SMOOTH, cb); },
-            CACHE_HIT(CMD_GET_ROBOT_POS_SMOOTH)) {
+            CACHE_HIT(CMD_GET_ROBOT_POS_SMOOTH)),
+    userSettingsCache(
+            CACHE_TTL_VERSION, [this](AsyncCache<UserSettingsData>::Callback cb) { fetchUserSettings(cb); },
+            CACHE_HIT(CMD_GET_USER_SETTINGS)) {
     TaskRegistry::add(this);
 }
 
@@ -288,6 +291,10 @@ void NeatoSerial::getCharger(std::function<void(bool, const ChargerData&)> callb
     chargerCache.get(callback);
 }
 
+void NeatoSerial::getUserSettings(std::function<void(bool, const UserSettingsData&)> callback) {
+    userSettingsCache.get(callback);
+}
+
 void NeatoSerial::getDigitalSensors(std::function<void(bool, const DigitalSensorData&)> callback) {
     getDigitalSensors(callback, PRIORITY_NORMAL);
 }
@@ -453,6 +460,16 @@ void NeatoSerial::fetchRobotPos(const char *cmd, std::function<void(bool, const 
     });
 }
 
+void NeatoSerial::fetchUserSettings(std::function<void(bool, const UserSettingsData&)> callback) {
+    enqueue(CMD_GET_USER_SETTINGS, [callback](bool ok, const String& raw) {
+        UserSettingsData data;
+        if (ok)
+            ok = parseUserSettingsData(raw, data);
+        if (callback)
+            callback(ok, data);
+    });
+}
+
 // -- Cache invalidation ------------------------------------------------------
 
 void NeatoSerial::invalidateState() {
@@ -470,6 +487,7 @@ void NeatoSerial::invalidateAll() {
     ldsCache.invalidate();
     robotPosRawCache.invalidate();
     robotPosSmoothCache.invalidate();
+    userSettingsCache.invalidate();
 }
 
 // -- Action command convenience methods --------------------------------------
@@ -613,6 +631,14 @@ bool NeatoSerial::setMotorSideBrush(bool on, int powerMw, std::function<void(boo
                         PRIORITY_MEDIUM);
             },
             PRIORITY_MEDIUM);
+}
+
+// -- User settings -----------------------------------------------------------
+
+bool NeatoSerial::setUserSetting(const String& key, const String& value, std::function<void(bool)> callback) {
+    userSettingsCache.invalidate();
+    String cmd = String(CMD_SET_USER_SETTINGS) + " " + key + " " + value;
+    return enqueue(cmd, wrapAction(callback));
 }
 
 // -- Power control -----------------------------------------------------------

--- a/firmware/src/neato_serial.h
+++ b/firmware/src/neato_serial.h
@@ -49,6 +49,7 @@ public:
 
     void getVersion(std::function<void(bool, const VersionData&)> callback);
     void getCharger(std::function<void(bool, const ChargerData&)> callback);
+    void getUserSettings(std::function<void(bool, const UserSettingsData&)> callback);
     void getDigitalSensors(std::function<void(bool, const DigitalSensorData&)> callback);
     void getDigitalSensors(std::function<void(bool, const DigitalSensorData&)> callback, CommandPriority priority);
     void getMotors(std::function<void(bool, const MotorData&)> callback);
@@ -69,6 +70,10 @@ public:
     bool setMotorVacuum(bool on, int speedPercent = 80, std::function<void(bool)> callback = nullptr);
     bool setMotorSideBrush(bool on, int powerMw = 5000, std::function<void(bool)> callback = nullptr);
     bool setTime(int dayOfWeek, int hour, int min, int sec, std::function<void(bool)> callback = nullptr);
+
+    // Set a single robot user setting via "SetUserSettings <key> <value>".
+    // Invalidates the user settings cache.
+    bool setUserSetting(const String& key, const String& value, std::function<void(bool)> callback = nullptr);
 
     // Power control: sends TestMode On, then SetSystemMode after inter-command delay.
     // action = "restart" (PowerCycle) or "shutdown" (Shutdown).
@@ -179,6 +184,7 @@ private:
     AsyncCache<LdsScanData> ldsCache;
     AsyncCache<RobotPosData> robotPosRawCache;
     AsyncCache<RobotPosData> robotPosSmoothCache;
+    AsyncCache<UserSettingsData> userSettingsCache;
 
     // Raw (uncached) fetch methods — enqueue the command and parse response
     void fetchVersion(std::function<void(bool, const VersionData&)> callback);
@@ -191,6 +197,7 @@ private:
     void fetchErrClear(std::function<void(bool, const ErrorData&)> callback);
     void fetchLdsScan(std::function<void(bool, const LdsScanData&)> callback);
     void fetchRobotPos(const char *cmd, std::function<void(bool, const RobotPosData&)> callback);
+    void fetchUserSettings(std::function<void(bool, const UserSettingsData&)> callback);
 };
 
 #endif // NEATO_SERIAL_H

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -87,6 +87,7 @@ void WebServer::registerApiRoutes() {
     registerGetRoute("/api/state", neato, &NeatoSerial::getState, {});
     registerGetRoute("/api/error", neato, &NeatoSerial::getErr, {});
     registerGetRoute("/api/lidar", neato, &NeatoSerial::getLdsScan, {});
+    registerGetRoute("/api/user-settings", neato, &NeatoSerial::getUserSettings, {});
 
     // -- Action endpoints ----------------------------------------------------
     // All parameterized actions use query strings: resource URL identifies the
@@ -97,6 +98,7 @@ void WebServer::registerApiRoutes() {
     registerPostRoute("/api/testmode", neato, &NeatoSerial::testMode, {"enable"});
     registerPostRoute("/api/power", neato, &NeatoSerial::powerControl, {"action"});
     registerPostRoute("/api/lidar/rotate", neato, &NeatoSerial::setLdsRotation, {"enable"});
+    registerPostRoute("/api/user-settings", neato, &NeatoSerial::setUserSetting, {"key", "value"});
 
     // Debug serial endpoint — send arbitrary serial command, returns raw response.
     // Only available when debug mode is enabled in settings.

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -255,6 +255,18 @@ const state = {
     ntfyOnError: true,
     ntfyOnAlert: true,
     ntfyOnDocking: true,
+    // Robot user settings (from GetUserSettings)
+    buttonClick: true,
+    melodies: true,
+    warnings: true,
+    ecoMode: false,
+    intenseClean: false,
+    binFullDetect: true,
+    wifi: true,
+    stealthLed: false,
+    filterChange: 2592000,
+    brushChange: 2592000,
+    dirtBin: 30,
     // Schedule (Mon=0..Sun=6)
     scheduleEnabled: true,
     sched0Hour: 9,
@@ -720,6 +732,49 @@ const routes = {
 
     "GET /repos/renjfk/OpenNeato/releases/latest": (_req, res) => {
         jsonResponse(res, { tag_name: "v1.0" });
+    },
+
+    "GET /api/user-settings": (_req, res) => {
+        jsonResponse(res, {
+            buttonClick: state.buttonClick,
+            melodies: state.melodies,
+            warnings: state.warnings,
+            ecoMode: state.ecoMode,
+            intenseClean: state.intenseClean,
+            binFullDetect: state.binFullDetect,
+            wifi: state.wifi,
+            stealthLed: state.stealthLed,
+            filterChange: state.filterChange,
+            brushChange: state.brushChange,
+            dirtBin: state.dirtBin,
+        });
+    },
+
+    "POST /api/user-settings": (_req, res, query) => {
+        const keyMap = {
+            ButtonClick: "buttonClick",
+            Melodies: "melodies",
+            Warnings: "warnings",
+            EcoMode: "ecoMode",
+            IntenseClean: "intenseClean",
+            BinFullDetect: "binFullDetect",
+            WiFi: "wifi",
+            StealthLED: "stealthLed",
+            FilterChange: "filterChange",
+            BrushChange: "brushChange",
+            DirtBin: "dirtBin",
+        };
+        const serialKey = query.key;
+        const value = query.value;
+        if (!serialKey || !value) return sendError(res, "missing key or value", 400);
+        const stateKey = keyMap[serialKey];
+        if (!stateKey) return sendError(res, "unknown key", 400);
+        if (["filterChange", "brushChange", "dirtBin"].includes(stateKey)) {
+            state[stateKey] = parseInt(value, 10);
+        } else {
+            state[stateKey] = value.toUpperCase() === "ON";
+        }
+        sendOk(res);
     },
 
     "GET /api/firmware/version": (_req, res) => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,6 +11,7 @@ import type {
     SettingsData,
     StateData,
     SystemData,
+    UserSettingsData,
 } from "./types";
 
 async function parseError(res: Response): Promise<string> {
@@ -141,5 +142,8 @@ export const api = {
             [`sched${day}On`]: on,
         }),
     setScheduleEnabled: (on: boolean) => put<SettingsData>("/api/settings", { scheduleEnabled: on }),
+    getUserSettings: () => get<UserSettingsData>("/api/user-settings"),
+    setUserSetting: (key: string, value: string) =>
+        post(`/api/user-settings?key=${encodeURIComponent(key)}&value=${encodeURIComponent(value)}`),
     sendSerial: (cmd: string) => sendSerial(cmd),
 };

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -663,6 +663,11 @@ body {
     overflow: hidden;
 }
 
+.settings-category.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 .settings-category-header {
     display: flex;
     align-items: center;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -83,6 +83,20 @@ export interface SettingsData {
     sched6On: boolean;
 }
 
+export interface UserSettingsData {
+    buttonClick: boolean;
+    melodies: boolean;
+    warnings: boolean;
+    ecoMode: boolean;
+    intenseClean: boolean;
+    binFullDetect: boolean;
+    wifi: boolean;
+    stealthLed: boolean;
+    filterChange: number; // seconds
+    brushChange: number; // seconds
+    dirtBin: number; // minutes
+}
+
 export interface LidarPoint {
     angle: number;
     dist: number;

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -7,6 +7,7 @@ import calendarSvg from "../assets/icons/calendar.svg?raw";
 import chipSvg from "../assets/icons/chip.svg?raw";
 import clockSvg from "../assets/icons/clock.svg?raw";
 import databaseSvg from "../assets/icons/database.svg?raw";
+import gearSvg from "../assets/icons/gear.svg?raw";
 import manualSvg from "../assets/icons/manual.svg?raw";
 import moonSvg from "../assets/icons/moon.svg?raw";
 import paletteSvg from "../assets/icons/palette.svg?raw";
@@ -21,7 +22,7 @@ import { ErrorBannerStack, useErrorStack } from "../components/error-banner";
 import { Icon } from "../components/icon";
 import { useNavigate } from "../components/router";
 import { usePolling } from "../hooks/use-polling";
-import type { FirmwareVersion, SystemData } from "../types";
+import type { FirmwareVersion, SystemData, UserSettingsData } from "../types";
 import {
     BRUSH_PRESETS,
     SIDE_BRUSH_PRESETS,
@@ -48,6 +49,23 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
     const navigate = useNavigate();
     const systemPoll = usePolling<SystemData>(api.getSystem, 10000);
     const system = systemPoll.data;
+    const userSettingsPoll = usePolling<UserSettingsData>(api.getUserSettings, 30000);
+    const [robotSettings, setRobotSettings] = useState<UserSettingsData | null>(null);
+    const [savingRobotSettings, setSavingRobotSettings] = useState(false);
+
+    // Sync polled data into local state — only on fresh poll results, not during/after saves.
+    // The ref tracks whether the user has made a local change; once they have, we stop
+    // overwriting from poll data until the next fresh poll result arrives.
+    const lastPollRef = useRef(userSettingsPoll.data);
+    useEffect(() => {
+        if (userSettingsPoll.data && userSettingsPoll.data !== lastPollRef.current && !savingRobotSettings) {
+            lastPollRef.current = userSettingsPoll.data;
+            setRobotSettings(userSettingsPoll.data);
+        }
+    }, [userSettingsPoll.data, savingRobotSettings]);
+
+    const robotSettingsDisabled = !robotSettings || savingRobotSettings || !firmware?.supported;
+
     const [errors, errorStack] = useErrorStack();
     const { rebooting, startRebootFlow } = useReboot(system?.uptime ?? 0);
 
@@ -99,6 +117,36 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         onSaveClick,
     } = useSettingsForm(errorStack, startRebootFlow);
 
+    // --- Robot user settings save ---
+    // Maps frontend field names to SetUserSettings serial command keys.
+    // StealthLed is inverted: frontend true = LEDs hidden = StealthLED ON.
+    const robotSettingKeys: Record<string, string> = {
+        buttonClick: "ButtonClick",
+        melodies: "Melodies",
+        warnings: "Warnings",
+        ecoMode: "EcoMode",
+        intenseClean: "IntenseClean",
+        binFullDetect: "BinFullDetect",
+        wifi: "WiFi",
+        stealthLed: "StealthLED",
+    };
+
+    const handleRobotSettingsChange = useCallback(
+        (field: keyof typeof robotSettingKeys, value: boolean) => {
+            if (!robotSettings) return;
+            setRobotSettings({ ...robotSettings, [field]: value });
+            setSavingRobotSettings(true);
+            const serialValue = value ? "ON" : "OFF";
+            api.setUserSetting(robotSettingKeys[field], serialValue)
+                .catch((e: unknown) => {
+                    errorStack.push(e instanceof Error ? e.message : "Failed to update robot settings");
+                    if (userSettingsPoll.data) setRobotSettings(userSettingsPoll.data);
+                })
+                .finally(() => setSavingRobotSettings(false));
+        },
+        [robotSettings, userSettingsPoll.data, errorStack],
+    );
+
     // --- Notification test ---
     const [testingNotif, setTestingNotif] = useState(false);
     const [notifTestResult, setNotifTestResult] = useState<string | null>(null);
@@ -129,6 +177,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
     const pendingNav = useRef<string | null>(null);
 
     // --- Robot power control ---
+    const [showRobotRestartConfirm, setShowRobotRestartConfirm] = useState(false);
     const [showRobotShutdownConfirm, setShowRobotShutdownConfirm] = useState(false);
     const [robotRestarting, setRobotRestarting] = useState(false);
     const robotRestartPollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -333,7 +382,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     </div>
                 </SettingsCategory>
 
-                <SettingsCategory title="Network" icon={wifiSvg}>
+                <SettingsCategory title="Device" icon={gearSvg}>
                     <div class="settings-section">
                         <div class="settings-section-title">Hostname</div>
                         <input
@@ -372,9 +421,6 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                             Lower power reduces range but improves stability on serial port power
                         </div>
                     </div>
-                </SettingsCategory>
-
-                <SettingsCategory title="Robot" icon={robotSvg}>
                     <div class="settings-section">
                         <div class="settings-section-title">Timezone</div>
                         <div class="settings-tz-select-wrap">
@@ -447,6 +493,14 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                                 Cleaning Schedule
                             </div>
                             <span class="settings-nav-chevron">&rsaquo;</span>
+                        </button>
+                    </div>
+                    <div class="settings-section">
+                        <button type="button" class="settings-nav-row" onClick={() => setShowRestartConfirm(true)}>
+                            <div class="settings-nav-row-left">
+                                <Icon svg={powerSvg} />
+                                Restart Device
+                            </div>
                         </button>
                     </div>
                 </SettingsCategory>
@@ -774,9 +828,127 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     {saveLabel}
                 </button>
 
-                <SettingsCategory title="Robot Power" icon={robotSvg}>
+                <SettingsCategory title="Robot" icon={robotSvg} disabled={firmware?.supported === false}>
                     <div class="settings-section">
-                        <button type="button" class="settings-nav-row" onClick={handleRobotRestart}>
+                        <div class="settings-section-title">Sound</div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Button clicks</span>
+                                <span class="settings-toggle-desc">Sound when pressing buttons</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.buttonClick ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("buttonClick", !robotSettings?.buttonClick)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle button clicks"
+                            />
+                        </div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Melodies</span>
+                                <span class="settings-toggle-desc">Startup and shutdown sounds</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.melodies ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("melodies", !robotSettings?.melodies)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle melodies"
+                            />
+                        </div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Warnings</span>
+                                <span class="settings-toggle-desc">Warning beeps</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.warnings ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("warnings", !robotSettings?.warnings)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle warnings"
+                            />
+                        </div>
+                    </div>
+                    <div class="settings-section">
+                        <div class="settings-section-title">Cleaning</div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Eco mode</span>
+                                <span class="settings-toggle-desc">
+                                    Lower brush and vacuum power, longer battery life
+                                </span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.ecoMode ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("ecoMode", !robotSettings?.ecoMode)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle eco mode"
+                            />
+                        </div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Intense clean</span>
+                                <span class="settings-toggle-desc">Double-pass cleaning for deeper clean</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.intenseClean ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("intenseClean", !robotSettings?.intenseClean)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle intense clean"
+                            />
+                        </div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Bin full detection</span>
+                                <span class="settings-toggle-desc">Alert when dust bin is full</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.binFullDetect ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() =>
+                                    handleRobotSettingsChange("binFullDetect", !robotSettings?.binFullDetect)
+                                }
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle bin full detection"
+                            />
+                        </div>
+                    </div>
+                    <div class="settings-section">
+                        <div class="settings-section-title">Power Saving</div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Robot WiFi</span>
+                                <span class="settings-toggle-desc">Unused with OpenNeato, disable to save power</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.wifi ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("wifi", !robotSettings?.wifi)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle robot WiFi"
+                            />
+                        </div>
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Stealth LEDs</span>
+                                <span class="settings-toggle-desc">Disable standby indicator lights</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${robotSettings?.stealthLed ? " on" : ""}${savingRobotSettings ? " pending" : ""}`}
+                                onClick={() => handleRobotSettingsChange("stealthLed", !robotSettings?.stealthLed)}
+                                disabled={robotSettingsDisabled}
+                                aria-label="Toggle stealth LEDs"
+                            />
+                        </div>
+                    </div>
+                    <div class="settings-section">
+                        <div class="settings-section-title">Power Control</div>
+                        <button type="button" class="settings-nav-row" onClick={() => setShowRobotRestartConfirm(true)}>
                             <div class="settings-nav-row-left">
                                 <Icon svg={powerSvg} />
                                 Restart Robot
@@ -797,15 +969,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     </div>
                 </SettingsCategory>
 
-                <SettingsCategory title="Device" icon={powerSvg}>
-                    <div class="settings-section">
-                        <button type="button" class="settings-nav-row" onClick={() => setShowRestartConfirm(true)}>
-                            <div class="settings-nav-row-left">
-                                <Icon svg={powerSvg} />
-                                Restart
-                            </div>
-                        </button>
-                    </div>
+                <SettingsCategory title="Danger Zone" icon={alertSvg}>
                     <div class="settings-section">
                         <button
                             type="button"
@@ -888,6 +1052,18 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                         fw.startUpload();
                     }}
                     onCancel={() => setShowUploadConfirm(false)}
+                />
+            )}
+
+            {showRobotRestartConfirm && (
+                <ConfirmDialog
+                    message="Restart the robot? It will be unavailable for a few seconds."
+                    confirmLabel="Restart"
+                    onConfirm={() => {
+                        setShowRobotRestartConfirm(false);
+                        handleRobotRestart();
+                    }}
+                    onCancel={() => setShowRobotRestartConfirm(false)}
                 />
             )}
 

--- a/frontend/src/views/settings/settings-category.tsx
+++ b/frontend/src/views/settings/settings-category.tsx
@@ -6,19 +6,25 @@ interface SettingsCategoryProps {
     title: string;
     icon: string;
     defaultOpen?: boolean;
+    disabled?: boolean;
     children: ComponentChildren;
 }
 
-export function SettingsCategory({ title, icon, defaultOpen = false, children }: SettingsCategoryProps) {
+export function SettingsCategory({ title, icon, defaultOpen = false, disabled, children }: SettingsCategoryProps) {
     const [open, setOpen] = useState(defaultOpen);
     return (
-        <div class={`settings-category${open ? " open" : ""}`}>
-            <button type="button" class="settings-category-header" onClick={() => setOpen(!open)}>
+        <div class={`settings-category${open && !disabled ? " open" : ""}${disabled ? " disabled" : ""}`}>
+            <button
+                type="button"
+                class="settings-category-header"
+                onClick={() => !disabled && setOpen(!open)}
+                disabled={disabled}
+            >
                 <div class="settings-category-title">
                     <Icon svg={icon} />
                     {title}
                 </div>
-                <span class="settings-category-chevron">&rsaquo;</span>
+                {!disabled && <span class="settings-category-chevron">&rsaquo;</span>}
             </button>
             <div class="settings-category-body">
                 <div class="settings-category-inner">{children}</div>


### PR DESCRIPTION
## Summary

- Add `GetUserSettings`/`SetUserSettings` serial protocol support with parser matching real D7 response labels
- Expose sound, cleaning behavior, and power saving toggles in settings page (save immediately to robot via serial)
- Reorganize settings categories: merge Network into Device, rename Robot Power to Robot (user settings + power controls), rename Device to Danger Zone
- Add disabled state for `SettingsCategory` component, disable Robot section for unsupported models
- Add confirm dialog for Restart Robot, pending animation on toggles during save
- Document `GetUserSettings`/`SetUserSettings` command and response format in serial protocol reference

Closes #6