### PR TITLE
Fix serial degradation from LittleFS logging overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,17 @@ Three top-level components: `firmware/` (ESP32 C/C++), `frontend/` (Preact SPA),
 
 ### Data Logging
 
+Logging is controlled by `logLevel` in settings (0=off, 1=info, 2=debug). Default
+is **off** — nothing written to LittleFS. Both info and debug auto-revert to off
+after a timeout (1 hour / 10 minutes) to prevent forgotten logging from degrading
+serial performance via LittleFS COW overhead.
+
 All significant events must be logged via `DataLogger` (injected by reference).
 `logEvent` is private — use typed public helpers (`logRequest`, `logWifi`, `logOta`,
 `logNtp`, `logGenericEvent`, `logNotification`). When adding a new manager that
 needs logging, add a new typed helper following the existing pattern. Log both
-success and failure outcomes.
+success and failure outcomes. At info level, only failures and state transitions
+are logged; at debug level, all serial commands including raw responses are included.
 
 ### Filesystem and Flash Wear
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ port, giving you a local web interface that works without any external dependenc
   is available on GitHub
 - **Settings page** for hostname, timezone, motor presets, notification topics, UART pins, theme (dark/light/auto), and
   more
-- **Event logging** with compressed JSONL files on LittleFS, browsable and downloadable from the UI
+- **Event logging** with configurable log levels (off/info/debug), compressed JSONL files on LittleFS, browsable and
+  downloadable from the UI; logging is off by default to minimize flash wear
 - **Factory reset** via 5-second button hold on the ESP32 or from the settings page
 - **Robot clock sync** — pushes NTP time to the robot automatically, re-syncs every 4 hours
 - **Flash tool** — standalone CLI that auto-detects the USB port, downloads the correct firmware from GitHub Releases,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,7 @@ Everything you need to set up, configure, and troubleshoot OpenNeato.
     - [Verifying the Connection](#verifying-the-connection)
     - [Quick Commands](#quick-commands)
 - [Troubleshooting](#troubleshooting)
-    - [Enabling Debug Mode](#enabling-debug-mode)
+    - [Enabling Logging](#enabling-logging)
     - [Collecting Logs](#collecting-logs)
     - [Downloading Cleaning Maps](#downloading-cleaning-maps)
     - [Factory Reset](#factory-reset)
@@ -314,17 +314,23 @@ Once connected, you can type single-key commands in the serial monitor at any ti
 If something isn't working as expected, use the built-in diagnostics tools to collect
 information before creating an issue.
 
-### Enabling Debug Mode
+### Enabling Logging
 
-Go to **Settings -> Diagnostics** and toggle **Debug mode** on. This enables:
+Go to **Settings -> Diagnostics** and set **Log Level**:
 
-- Verbose event logging (sensor payloads, raw serial responses)
-- The raw serial console endpoint (`POST /api/serial?cmd=<command>`) for direct robot
-  communication
+- **Off** (default) — no events written to storage, zero flash wear
+- **Info** — logs errors, timeouts, state transitions, boot, WiFi, OTA, NTP, cleaning events,
+  and notifications. Auto-reverts to off after 1 hour.
+- **Debug** — everything in Info plus all serial commands with raw responses. Auto-reverts to
+  off after 10 minutes.
+
+The raw serial console endpoint (`POST /api/serial?cmd=<command>`) for direct robot
+communication is always available regardless of log level.
 
 > [!NOTE]
-> Debug mode auto-expires after 10 minutes to prevent forgotten verbose logging from filling
-> up storage. You can re-enable it if you need more time.
+> Logging writes to flash storage using LittleFS. Higher levels generate more writes, which
+> increases flash wear and can slow serial communication as the filesystem fills up. Use Info
+> or Debug only when actively diagnosing an issue.
 
 ### Collecting Logs
 
@@ -369,8 +375,8 @@ Two ways to factory reset:
 
 Before creating an issue on GitHub:
 
-1. **Enable debug mode** (Settings -> Diagnostics -> Debug mode)
-2. **Reproduce the problem** while debug mode is active
+1. **Set log level to Debug** (Settings -> Diagnostics -> Log Level -> Debug)
+2. **Reproduce the problem** while logging is active
 3. **Download the logs** (Settings -> Diagnostics -> Logs)
 4. **If the issue involves cleaning**: download the relevant cleaning session from History
 5. Create an issue at [github.com/renjfk/OpenNeato/issues](https://github.com/renjfk/OpenNeato/issues)

--- a/firmware/src/cleaning_history.cpp
+++ b/firmware/src/cleaning_history.cpp
@@ -342,9 +342,18 @@ void CleaningHistory::bufferLine(const String& line) {
 void CleaningHistory::flushWriteBuffer() {
     if (writeBuffer.empty() || !activeFile)
         return;
+    // Build a single string and write once to minimize LittleFS COW metadata updates
+    String batch;
+    size_t total = 0;
     for (const auto& line: writeBuffer) {
-        activeFile.println(line);
+        total += line.length() + 1;
     }
+    batch.reserve(total);
+    for (const auto& line: writeBuffer) {
+        batch += line;
+        batch += '\n';
+    }
+    activeFile.write(reinterpret_cast<const uint8_t *>(batch.c_str()), batch.length());
     activeFile.flush();
     writeBuffer.clear();
     lastFlushMs = millis();

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -96,6 +96,7 @@ enum CommandStatus {
 #define LOG_CURRENT_FILE "/log/current.jsonl"
 #define LOG_FLUSH_INTERVAL_MS 30000 // Flush write buffer to filesystem every 30 seconds (reduces flash wear)
 #define LOG_FLUSH_MAX_LINES 128 // Also flush when buffer reaches this many lines
+#define LOG_ENFORCE_LIMITS_MS 30000 // Check log dir size/count limits every 30s (not every 50ms tick)
 
 // NVS (Non-Volatile Storage) — single shared namespace for all settings
 #define NVS_NAMESPACE "neato"
@@ -109,8 +110,17 @@ enum CommandStatus {
 
 // NVS keys — Settings
 #define NVS_KEY_HOSTNAME "hostname"
-#define NVS_KEY_DEBUG "debug"
-#define DEBUG_AUTO_OFF_MS 600000 // Auto-disable debug mode after 10 minutes to prevent forgotten verbose logging
+#define NVS_KEY_LOG_LEVEL "log_level"
+#define NVS_KEY_DEBUG "debug" // TODO: Remove after v0.5 — legacy key, migrated to log_level on first boot
+#define LOG_LEVEL_AUTO_OFF_DEBUG_MS 600000 // Auto-revert debug -> off after 10 minutes
+#define LOG_LEVEL_AUTO_OFF_INFO_MS 3600000 // Auto-revert info -> off after 1 hour
+
+// Log levels — controls what gets written to LittleFS. Default off to minimize
+// flash wear. LittleFS copy-on-write metadata updates on every write stall
+// the main loop and degrade serial response times as storage fills up.
+#define LOG_LEVEL_OFF 0 // Nothing written to LittleFS (default)
+#define LOG_LEVEL_INFO 1 // Errors, state transitions, boot, wifi, ota, ntp, cleaning events, notifications
+#define LOG_LEVEL_DEBUG 2 // Everything in Info + all serial commands + raw responses
 #define NVS_KEY_WIFI_TX_POWER "wifi_tx_pwr"
 #define NVS_KEY_UART_TX_PIN "uart_tx_pin"
 #define NVS_KEY_UART_RX_PIN "uart_rx_pin"

--- a/firmware/src/data_logger.cpp
+++ b/firmware/src/data_logger.cpp
@@ -168,8 +168,10 @@ void DataLogger::tick() {
         }
     }
 
-    // Enforce space and file count limits (one delete per loop iteration)
-    if (!compressing && !bulkDeletePending) {
+    // Enforce space and file count limits — throttled to once per 30s.
+    // Previously ran every 50ms tick, causing constant LittleFS directory scans
+    // that block the main loop and degrade serial response times.
+    if (!compressing && !bulkDeletePending && enforceLimitsTicker.elapsed(LOG_ENFORCE_LIMITS_MS)) {
         enforceLimits();
     }
 
@@ -233,10 +235,17 @@ void DataLogger::flushBuffer() {
         return;
     }
 
+    // Build a single string and write once to minimize LittleFS COW metadata
+    // updates. Previously each println() triggered a separate COW + B-tree
+    // update, causing 50-300ms stalls that blocked the UART state machine.
+    String batch;
+    batch.reserve(bufferBytes());
     for (const auto& line: writeBuffer) {
-        size_t written = f.println(line);
-        currentFileSize += written;
+        batch += line;
+        batch += '\n';
     }
+    size_t written = f.write(reinterpret_cast<const uint8_t *>(batch.c_str()), batch.length());
+    currentFileSize += written;
     f.close();
     writeBuffer.clear();
     lastFlushMs = millis();
@@ -409,6 +418,11 @@ void DataLogger::enforceLimits() {
 // -- Public logging methods --------------------------------------------------
 
 void DataLogger::logEvent(const String& type, const std::vector<Field>& fields) {
+    // Skip if logging is off — no filesystem I/O, no buffer growth.
+    // If logLevelCheck is not yet wired (null during early boot), default to off.
+    if (!logLevelCheck || logLevelCheck() == LOG_LEVEL_OFF)
+        return;
+
     String line = "{\"t\":" + String(static_cast<long>(sysMgr.now())) + ",\"typ\":\"" + type + "\",\"d\":{" +
                   fieldsToJsonInner(fields) + "}}";
     bufferLine(line);
@@ -509,10 +523,17 @@ void DataLogger::logBootEvent() {
 
 void DataLogger::onCommand(const String& cmd, CommandStatus status, unsigned long ms, const String& raw, int queueDepth,
                            size_t respBytes, unsigned long cacheAgeMs) {
+    int level = logLevelCheck ? logLevelCheck() : LOG_LEVEL_OFF;
+    if (level == LOG_LEVEL_OFF)
+        return;
+
     // Skip cache hits — they are memory lookups, not real serial I/O.
-    // Logging every cache hit is the dominant source of buffer churn during
-    // normal dashboard polling (GetState/GetErr every 2s from multiple consumers).
     if (cacheAgeMs > 0)
+        return;
+
+    // Info level: only log failures (timeouts, errors, queue_full, unsupported).
+    // Successful routine polls are noise at info level.
+    if (level == LOG_LEVEL_INFO && status == CMD_SUCCESS)
         return;
 
     // Convert status enum to string for JSON
@@ -541,13 +562,13 @@ void DataLogger::onCommand(const String& cmd, CommandStatus status, unsigned lon
             break;
     }
 
-    // Log command metadata; include raw response only when debug logging is enabled
+    // Log command metadata; include raw response only at debug level
     std::vector<Field> fields = {{"cmd", cmd, FIELD_STRING},
                                  {"status", statusStr, FIELD_STRING},
                                  {"ms", String(ms), FIELD_INT},
                                  {"q", String(queueDepth), FIELD_INT},
                                  {"bytes", String(respBytes), FIELD_INT}};
-    if (debugCheck && debugCheck())
+    if (level >= LOG_LEVEL_DEBUG)
         fields.push_back({"resp", raw, FIELD_STRING});
     logEvent("command", fields);
 }

--- a/firmware/src/data_logger.h
+++ b/firmware/src/data_logger.h
@@ -98,10 +98,11 @@ public:
     void logGenericEvent(const String& category, const std::vector<Field>& extra = {});
     void logNotification(const String& category, const String& message, bool success);
 
-    // Debug mode check — when set and returns true, sensor payloads are
-    // included in request log entries. Wired by main.cpp to SettingsManager.
-    using DebugCheck = std::function<bool()>;
-    void setDebugCheck(DebugCheck check) { debugCheck = check; }
+    // Log level check — returns current log level from SettingsManager.
+    // 0=off (no logging), 1=info (events only), 2=debug (all commands + raw responses).
+    // Wired by main.cpp to SettingsManager.
+    using LogLevelCheck = std::function<int()>;
+    void setLogLevelCheck(LogLevelCheck check) { logLevelCheck = check; }
 
     // -- Log file management (for API) --------------------------------------
 
@@ -115,7 +116,7 @@ private:
 
     NeatoSerial& neato;
     SystemManager& sysMgr;
-    DebugCheck debugCheck;
+    LogLevelCheck logLevelCheck;
 
     void logEvent(const String& type, const std::vector<Field>& fields);
 
@@ -153,6 +154,7 @@ private:
     bool compressStep(); // Returns true when compression is complete
 
     void enforceLimits();
+    Ticker enforceLimitsTicker; // Throttle enforceLimits to once per 30s instead of every 50ms tick
 
     // -- Deferred bulk delete ------------------------------------------------
     bool bulkDeletePending = false;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -151,7 +151,7 @@ void setup() {
     // Initialize data logger (LittleFS, serial command hook)
     // Note: WiFi/OTA events buffered in memory above get flushed once LittleFS mounts here.
     LOG("BOOT", "Initializing data logger...");
-    dataLogger.setDebugCheck([&]() { return settingsManager.get().debug; });
+    dataLogger.setLogLevelCheck([&]() { return settingsManager.get().logLevel; });
     dataLogger.begin();
 
     // Fetch robot time as fallback clock

--- a/firmware/src/manual_clean_manager.cpp
+++ b/firmware/src/manual_clean_manager.cpp
@@ -16,6 +16,7 @@ bool ManualCleanManager::enable(bool doEnable, std::function<void(bool)> callbac
         }
 
         enabling = true;
+        enablingStartMs = millis();
         LOG("MANUAL", "Enabling manual mode...");
 
         // Step 1: Enter TestMode
@@ -198,16 +199,27 @@ bool ManualCleanManager::setMotors(bool brush, bool vacuum, bool sideBrush, std:
 // -- Loop (safety polling + watchdog) ----------------------------------------
 
 void ManualCleanManager::tick() {
+    // Recover from stuck enabling state — if the enable callback never fires
+    // (e.g. serial queue was full when TestMode/LDS commands were enqueued),
+    // reset after 10s so the user can retry instead of being locked out forever.
+    if (enabling && enablingStartMs > 0 && millis() - enablingStartMs >= 10000) {
+        LOG("MANUAL", "Enable timeout — resetting enabling flag after 10s");
+        enabling = false;
+        enablingStartMs = 0;
+    }
+
     if (!active)
         return;
 
-    // Safety polling — bumpers
-    if (safetyTicker.elapsed(MANUAL_SAFETY_POLL_MS)) {
+    // Safety polling — bumpers (skip if serial queue is more than half full
+    // to prevent queue saturation that blocks all other commands including
+    // TestMode entry and move commands — root cause of #18)
+    if (safetyTicker.elapsed(MANUAL_SAFETY_POLL_MS) && serial.queueDepth() <= NEATO_QUEUE_MAX_SIZE / 2) {
         pollBumpers();
     }
 
     // Stall detection — poll motor odometry while wheels are moving
-    if (wheelsMoving && stallTicker.elapsed(MANUAL_STALL_POLL_MS)) {
+    if (wheelsMoving && stallTicker.elapsed(MANUAL_STALL_POLL_MS) && serial.queueDepth() <= NEATO_QUEUE_MAX_SIZE / 2) {
         pollStall();
     }
 

--- a/firmware/src/manual_clean_manager.h
+++ b/firmware/src/manual_clean_manager.h
@@ -64,6 +64,7 @@ private:
     NeatoSerial& serial;
     bool active = false;
     bool enabling = false; // Transition in progress (enable sequence)
+    unsigned long enablingStartMs = 0; // millis() when enable() started (for timeout recovery)
     bool disabling = false; // Transition in progress (disable sequence)
 
     // Current motor state (to avoid redundant commands on toggle)

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -12,10 +12,21 @@ SettingsManager::SettingsManager(Preferences& prefs) : prefs(prefs) {}
 
 // -- Lifecycle ---------------------------------------------------------------
 
+static const char *logLevelStr(int level) {
+    switch (level) {
+        case LOG_LEVEL_INFO:
+            return "info";
+        case LOG_LEVEL_DEBUG:
+            return "debug";
+        default:
+            return "off";
+    }
+}
+
 void SettingsManager::begin() {
     load();
-    LOG("SETTINGS", "Loaded: hostname=%s tz=%s debug=%s txPower=%d (%.1f dBm) uart=TX%d/RX%d sched=%s",
-        current.hostname.c_str(), current.tz.c_str(), current.debug ? "true" : "false", current.wifiTxPower,
+    LOG("SETTINGS", "Loaded: hostname=%s tz=%s logLevel=%s txPower=%d (%.1f dBm) uart=TX%d/RX%d sched=%s",
+        current.hostname.c_str(), current.tz.c_str(), logLevelStr(current.logLevel), current.wifiTxPower,
         current.wifiTxPower * 0.25f, current.uartTxPin, current.uartRxPin, current.scheduleEnabled ? "on" : "off");
 }
 
@@ -24,9 +35,21 @@ void SettingsManager::begin() {
 void SettingsManager::load() {
     current.hostname = prefs.getString(NVS_KEY_HOSTNAME, DEFAULT_HOSTNAME);
     current.tz = prefs.getString(NVS_KEY_TIMEZONE, NTP_DEFAULT_TZ);
-    current.debug = prefs.getBool(NVS_KEY_DEBUG, false);
-    if (current.debug)
-        debugEnabledAt = millis(); // Start auto-expire timer for persisted debug state
+
+    // TODO: Remove this migration block after v0.5 — all devices will have migrated by then.
+    // Migrate legacy "debug" bool to "log_level" int on first boot after upgrade.
+    // Old firmware stored debug=true/false; new firmware uses logLevel 0/1/2.
+    if (prefs.isKey(NVS_KEY_DEBUG)) {
+        bool oldDebug = prefs.getBool(NVS_KEY_DEBUG, false);
+        current.logLevel = oldDebug ? LOG_LEVEL_DEBUG : LOG_LEVEL_OFF;
+        prefs.remove(NVS_KEY_DEBUG);
+        prefs.putInt(NVS_KEY_LOG_LEVEL, current.logLevel);
+        LOG("SETTINGS", "Migrated debug=%s -> logLevel=%s", oldDebug ? "true" : "false", logLevelStr(current.logLevel));
+    } else {
+        current.logLevel = prefs.getInt(NVS_KEY_LOG_LEVEL, LOG_LEVEL_OFF);
+    }
+    if (current.logLevel > LOG_LEVEL_OFF)
+        logLevelEnabledAt = millis(); // Start auto-expire timer for persisted log level
     current.wifiTxPower = prefs.getInt(NVS_KEY_WIFI_TX_POWER, WIFI_DEFAULT_TX_POWER);
     current.uartTxPin = prefs.getInt(NVS_KEY_UART_TX_PIN, NEATO_DEFAULT_TX_PIN);
     current.uartRxPin = prefs.getInt(NVS_KEY_UART_RX_PIN, NEATO_DEFAULT_RX_PIN);
@@ -51,7 +74,7 @@ void SettingsManager::load() {
 void SettingsManager::save() {
     prefs.putString(NVS_KEY_HOSTNAME, current.hostname);
     prefs.putString(NVS_KEY_TIMEZONE, current.tz);
-    prefs.putBool(NVS_KEY_DEBUG, current.debug);
+    prefs.putInt(NVS_KEY_LOG_LEVEL, current.logLevel);
     prefs.putInt(NVS_KEY_WIFI_TX_POWER, current.wifiTxPower);
     prefs.putInt(NVS_KEY_UART_TX_PIN, current.uartTxPin);
     prefs.putInt(NVS_KEY_UART_RX_PIN, current.uartRxPin);
@@ -76,13 +99,18 @@ void SettingsManager::save() {
 // -- Debug auto-expire -------------------------------------------------------
 
 const Settings& SettingsManager::get() {
-    // Auto-disable debug mode after timeout to prevent forgotten verbose logging
-    // that inflates log files (raw serial responses can be kilobytes per entry)
-    if (current.debug && debugEnabledAt > 0 && millis() - debugEnabledAt >= DEBUG_AUTO_OFF_MS) {
-        current.debug = false;
-        debugEnabledAt = 0;
-        save();
-        LOG("SETTINGS", "Debug auto-disabled after timeout");
+    // Auto-revert log level to off after timeout to prevent forgotten verbose
+    // logging that fills flash and degrades serial performance via LittleFS COW.
+    if (current.logLevel > LOG_LEVEL_OFF && logLevelEnabledAt > 0) {
+        unsigned long timeout =
+                (current.logLevel >= LOG_LEVEL_DEBUG) ? LOG_LEVEL_AUTO_OFF_DEBUG_MS : LOG_LEVEL_AUTO_OFF_INFO_MS;
+        if (millis() - logLevelEnabledAt >= timeout) {
+            LOG("SETTINGS", "Log level auto-reverted: %s -> off (after %lu ms)", logLevelStr(current.logLevel),
+                timeout);
+            current.logLevel = LOG_LEVEL_OFF;
+            logLevelEnabledAt = 0;
+            save();
+        }
     }
     return current;
 }
@@ -122,11 +150,16 @@ ApplyResult SettingsManager::apply(const String& json) {
         LOG("SETTINGS", "Timezone -> %s", current.tz.c_str());
     }
 
-    if (incoming.debug != current.debug) {
-        current.debug = incoming.debug;
+    if (incoming.logLevel != current.logLevel) {
+        int clamped = constrain(incoming.logLevel, LOG_LEVEL_OFF, LOG_LEVEL_DEBUG);
+        current.logLevel = clamped;
         changed = true;
-        debugEnabledAt = current.debug ? millis() : 0;
-        LOG("SETTINGS", "Debug -> %s%s", current.debug ? "on" : "off", current.debug ? " (auto-off in 10 min)" : "");
+        logLevelEnabledAt = (current.logLevel > LOG_LEVEL_OFF) ? millis() : 0;
+        unsigned long timeout = (current.logLevel >= LOG_LEVEL_DEBUG)  ? LOG_LEVEL_AUTO_OFF_DEBUG_MS
+                                : (current.logLevel == LOG_LEVEL_INFO) ? LOG_LEVEL_AUTO_OFF_INFO_MS
+                                                                       : 0;
+        LOG("SETTINGS", "Log level -> %s%s", logLevelStr(current.logLevel),
+            timeout > 0 ? String(" (auto-off in " + String(timeout / 60000) + " min)").c_str() : "");
     }
 
     if (incoming.wifiTxPower != current.wifiTxPower) {
@@ -257,7 +290,7 @@ std::vector<Field> Settings::toFields() const {
     std::vector<Field> f = {
             {"hostname", hostname, FIELD_STRING},
             {"tz", tz, FIELD_STRING},
-            {"debug", debug ? "true" : "false", FIELD_BOOL},
+            {"logLevel", String(logLevel), FIELD_INT},
             {"wifiTxPower", String(wifiTxPower), FIELD_INT},
             {"uartTxPin", String(uartTxPin), FIELD_INT},
             {"uartRxPin", String(uartRxPin), FIELD_INT},
@@ -295,8 +328,8 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
         tz = f->value;
         applied = true;
     }
-    if ((f = findField(fields, "debug")) && f->type == FIELD_BOOL) {
-        debug = (f->value == "true");
+    if ((f = findField(fields, "logLevel")) && f->type == FIELD_INT) {
+        logLevel = f->value.toInt();
         applied = true;
     }
     if ((f = findField(fields, "wifiTxPower")) && f->type == FIELD_INT) {

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -18,7 +18,7 @@ struct SchedDay {
 struct Settings : public JsonSerializable {
     String hostname = DEFAULT_HOSTNAME;
     String tz = NTP_DEFAULT_TZ;
-    bool debug = false;
+    int logLevel = LOG_LEVEL_OFF; // 0=off, 1=info, 2=debug (auto-expires back to off)
     int wifiTxPower = WIFI_DEFAULT_TX_POWER; // 0.25 dBm units (34 = 8.5 dBm)
     int uartTxPin = NEATO_DEFAULT_TX_PIN; // ESP GPIO -> Robot RX
     int uartRxPin = NEATO_DEFAULT_RX_PIN; // ESP GPIO <- Robot TX
@@ -52,7 +52,7 @@ public:
 
     void begin();
 
-    // Read current settings (auto-expires debug mode if timed out)
+    // Read current settings (auto-expires log level if timed out)
     const Settings& get();
 
     // Apply a partial update — only fields present in the JSON body are written.
@@ -76,7 +76,7 @@ private:
     TzChangeCallback tzChangeCb;
     TxPowerChangeCallback txPowerChangeCb;
     RebootCallback rebootCb;
-    unsigned long debugEnabledAt = 0; // millis() when debug was turned on (0 = off)
+    unsigned long logLevelEnabledAt = 0; // millis() when log level was changed from off (0 = off/never)
 
     void load();
     void save();

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -98,17 +98,11 @@ void WebServer::registerApiRoutes() {
     registerPostRoute("/api/power", neato, &NeatoSerial::powerControl, {"action"});
     registerPostRoute("/api/lidar/rotate", neato, &NeatoSerial::setLdsRotation, {"enable"});
 
-    // Debug serial endpoint — send arbitrary serial command, returns raw response.
-    // Only available when debug mode is enabled in settings.
+    // Serial endpoint — send arbitrary serial command, returns raw response.
+    // Always available (no debug gate — useful for diagnostics without enabling verbose logging).
     server.on("/api/serial", HTTP_POST, [this](AsyncWebServerRequest *request) {
         lastApiActivity = millis();
         unsigned long startMs = lastApiActivity;
-
-        if (!settingsMgr.get().debug) {
-            logger.logRequest(HTTP_POST, "/api/serial", 403, millis() - startMs);
-            sendError(request, 403, "debug mode disabled");
-            return;
-        }
 
         if (!request->hasParam("cmd")) {
             logger.logRequest(HTTP_POST, "/api/serial", 400, millis() - startMs);

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -239,7 +239,7 @@ const state = {
     lidarLowQuality: false,
     lidarSlowRotation: false,
     tz: "UTC0",
-    debug: false,
+    logLevel: 0,
     wifiTxPower: 60, // 15 dBm in 0.25 dBm units
     uartTxPin: 3,
     uartRxPin: 4,
@@ -686,7 +686,7 @@ const routes = {
         const s = {};
         const keys = [
             "tz",
-            "debug",
+            "logLevel",
             "wifiTxPower",
             "uartTxPin",
             "uartRxPin",
@@ -896,7 +896,7 @@ const handleRequest = async (req, res) => {
             const data = JSON.parse(body);
             await new Promise((r) => setTimeout(r, rand(300, 600)));
             if (data.tz !== undefined) state.tz = data.tz;
-            if (data.debug !== undefined) state.debug = data.debug;
+            if (data.logLevel !== undefined) state.logLevel = data.logLevel;
             if (data.wifiTxPower !== undefined) state.wifiTxPower = data.wifiTxPower;
             const pinsChanged =
                 (data.uartTxPin !== undefined && data.uartTxPin !== state.uartTxPin) ||
@@ -930,7 +930,7 @@ const handleRequest = async (req, res) => {
             const s = {};
             const keys = [
                 "tz",
-                "debug",
+                "logLevel",
                 "wifiTxPower",
                 "uartTxPin",
                 "uartRxPin",
@@ -960,9 +960,8 @@ const handleRequest = async (req, res) => {
         }
     }
 
-    // Debug serial endpoint — gated on debug mode
+    // Serial endpoint — always available (no log level gate)
     if (req.method === "POST" && path === "/api/serial") {
-        if (!state.debug) return sendError(res, "debug mode disabled", 403);
         const cmd = query.cmd;
         if (!cmd) return sendError(res, "missing cmd", 400);
         // Simulate serial response with a delay

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,7 +43,7 @@ export interface SystemData {
 // Per-day schedule fields: sched{0-6}Hour, sched{0-6}Min, sched{0-6}On (Mon=0..Sun=6)
 export interface SettingsData {
     tz: string;
-    debug: boolean;
+    logLevel: number; // 0=off, 1=info, 2=debug
     wifiTxPower: number; // 0.25 dBm units (e.g. 34 = 8.5 dBm)
     uartTxPin: number;
     uartRxPin: number;

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -56,8 +56,8 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
     const {
         tz,
         setTz,
-        debug,
-        setDebug,
+        logLevel,
+        setLogLevel,
         wifiTxPower,
         setWifiTxPower,
         uartTxPin,
@@ -739,19 +739,22 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
 
                 <SettingsCategory title="Diagnostics" icon={stethoscopeSvg}>
                     <div class="settings-section">
-                        <div class="settings-section-title">Diagnostics</div>
-                        <div class="settings-toggle-row">
-                            <div class="settings-toggle-label">
-                                <span class="settings-toggle-title">Debug mode</span>
-                                <span class="settings-toggle-desc">Verbose logging and serial console endpoint</span>
-                            </div>
-                            <button
-                                type="button"
-                                class={`settings-toggle${debug ? " on" : ""}`}
-                                onClick={() => setDebug(!debug)}
+                        <div class="settings-section-title">Log Level</div>
+                        <div class="settings-tz-select-wrap">
+                            <select
+                                class="settings-tz-select"
+                                value={logLevel}
+                                onChange={(e) => setLogLevel(parseInt((e.target as HTMLSelectElement).value, 10))}
                                 disabled={saving}
-                                aria-label="Toggle debug mode"
-                            />
+                            >
+                                <option value={0}>Off (default)</option>
+                                <option value={1}>Info (auto-off after 1 hour)</option>
+                                <option value={2}>Debug (auto-off after 10 min)</option>
+                            </select>
+                        </div>
+                        <div class="settings-robot-time">
+                            Logging writes to flash storage. Higher levels increase wear and can slow serial
+                            communication.
                         </div>
                     </div>
                     <div class="settings-section">

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -99,7 +99,7 @@ export const SIDE_BRUSH_PRESETS: SideBrushPreset[] = [
 
 export const DEFAULT_SERVER: SettingsData = {
     tz: "UTC0",
-    debug: false,
+    logLevel: 0,
     wifiTxPower: 60,
     uartTxPin: 3,
     uartRxPin: 4,

--- a/frontend/src/views/settings/use-settings-form.ts
+++ b/frontend/src/views/settings/use-settings-form.ts
@@ -8,7 +8,7 @@ import { DEFAULT_SERVER } from "./constants";
 export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: () => void) {
     // Local form state
     const [tz, setTz] = useState<string>("UTC0");
-    const [debug, setDebug] = useState(false);
+    const [logLevel, setLogLevel] = useState(0);
     const [wifiTxPower, setWifiTxPower] = useState(60);
     const [uartTxPin, setUartTxPin] = useState(3);
     const [uartRxPin, setUartRxPin] = useState(4);
@@ -40,7 +40,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         if (fetched) {
             server.current = { ...fetched };
             setTz(fetched.tz);
-            setDebug(fetched.debug);
+            setLogLevel(fetched.logLevel);
             setWifiTxPower(fetched.wifiTxPower);
             setUartTxPin(fetched.uartTxPin);
             setUartRxPin(fetched.uartRxPin);
@@ -65,7 +65,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     const isDirty =
         settingsLoaded &&
         (tz !== server.current.tz ||
-            debug !== server.current.debug ||
+            logLevel !== server.current.logLevel ||
             wifiTxPower !== server.current.wifiTxPower ||
             uartTxPin !== server.current.uartTxPin ||
             uartRxPin !== server.current.uartRxPin ||
@@ -109,7 +109,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     const buildPatch = useCallback((): Partial<SettingsData> => {
         const patch: Partial<SettingsData> = {};
         if (tz !== server.current.tz) patch.tz = tz;
-        if (debug !== server.current.debug) patch.debug = debug;
+        if (logLevel !== server.current.logLevel) patch.logLevel = logLevel;
         if (wifiTxPower !== server.current.wifiTxPower) patch.wifiTxPower = wifiTxPower;
         if (uartTxPin !== server.current.uartTxPin) patch.uartTxPin = uartTxPin;
         if (uartRxPin !== server.current.uartRxPin) patch.uartRxPin = uartRxPin;
@@ -127,7 +127,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         return patch;
     }, [
         tz,
-        debug,
+        logLevel,
         wifiTxPower,
         uartTxPin,
         uartRxPin,
@@ -181,8 +181,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         // Form fields
         tz,
         setTz,
-        debug,
-        setDebug,
+        logLevel,
+        setLogLevel,
         wifiTxPower,
         setWifiTxPower,
         uartTxPin,


### PR DESCRIPTION
## Summary

- Replace `debug` boolean with `logLevel` (off/info/debug), default off
- Batch flush writes into single `f.write()` instead of N `f.println()` calls
- Throttle `enforceLimits()` dir scans from every 50ms to once per 30s
- Guard manual safety polls on serial queue depth to prevent saturation
- Add 10s timeout on stuck `enabling` state for manual mode retry
- Ungated `/api/serial` endpoint
- Migrate legacy NVS `debug` key to `logLevel` on first boot
- Auto-revert info/debug to off after timeout (1hr / 10min)

Fixes #18