### PR TITLE
Add multiple daily schedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .pio
 .cache
-compile_commands.json
+firmware/compile_commands.json
 firmware/src/web_assets.h
 frontend/node_modules
 frontend/dist

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ port, giving you a local web interface that works without any external dependenc
   brush), bumper/wheel-lift/stall safety warnings
 - **Live cleaning map** — watch the robot's path during an active cleaning session in the History view, rendered on a
   canvas with coverage overlay
-- **7-day cleaning scheduler** managed entirely on the ESP32 (doesn't use the robot's built-in schedule commands)
+- **7-day cleaning scheduler** with two slots per day, managed entirely on the ESP32 (doesn't use the robot's built-in schedule commands)
 - **Cleaning history** with recorded robot paths rendered as coverage maps, session stats like duration, distance, area
   covered, and battery usage; individual session import/export for backup and restore
 - **Push notifications** via [ntfy.sh](https://ntfy.sh); get notified when cleaning is done, an error occurs, a

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -148,6 +148,7 @@ enum CommandStatus {
 // Per-day keys use suffix: "s0h","s0m","s0on" .. "s6h","s6m","s6on" (Mon=0..Sun=6)
 // Built programmatically in SettingsManager — no individual defines needed.
 #define SCHEDULE_DAYS 7
+#define SCHEDULE_SLOTS_PER_DAY 2 // Two time slots per day (e.g. morning + afternoon)
 #define SCHEDULE_CHECK_INTERVAL_MS 30000 // Check schedule against NTP time every 30s
 #define SCHEDULE_WINDOW_MINS 5 // Fire if current time is 0..N minutes after scheduled slot
 

--- a/firmware/src/scheduler.cpp
+++ b/firmware/src/scheduler.cpp
@@ -28,58 +28,71 @@ void Scheduler::tick() {
     int day = toSchedDay(tm.tm_wday);
     int nowMins = tm.tm_hour * 60 + tm.tm_min;
 
-    const SchedDay& slot = s.sched[day];
-    if (!slot.on)
-        return;
+    // Reset fired guards when the day rolls over
+    if (day != firedDay) {
+        firedDay = day;
+        for (int& fs: firedSlots)
+            fs = -1;
+    }
 
-    int schedMins = slot.hour * 60 + slot.minute;
-    int elapsed = nowMins - schedMins;
+    const SchedDay& daySlots = s.sched[day];
 
-    // Fire if we're within 0..SCHEDULE_WINDOW_MINS after the scheduled time
-    if (elapsed < 0 || elapsed > SCHEDULE_WINDOW_MINS)
-        return;
+    for (int si = 0; si < SCHEDULE_SLOTS_PER_DAY; si++) {
+        const SchedSlot& slot = daySlots.slots[si];
+        if (!slot.on)
+            continue;
 
-    // Already fired for this slot today?
-    if (day == firedDay && schedMins == firedSlot)
-        return;
+        int schedMins = slot.hour * 60 + slot.minute;
+        int elapsed = nowMins - schedMins;
 
-    // Build common log fields for this slot
-    String slotStr = String(schedMins / 60) + ":" + (schedMins % 60 < 10 ? "0" : "") + String(schedMins % 60);
+        // Fire if we're within 0..SCHEDULE_WINDOW_MINS after the scheduled time
+        if (elapsed < 0 || elapsed > SCHEDULE_WINDOW_MINS)
+            continue;
 
-    // Check robot state before triggering (uses cached state — no extra serial command)
-    serial.getState([this, day, schedMins, slotStr](bool ok, const RobotState& state) {
-        if (!ok) {
-            LOG("SCHED", "GetState failed, cannot check robot state for slot %s", slotStr.c_str());
-            dataLogger.logGenericEvent("scheduler_state_error",
-                                       {{"day", String(day), FIELD_INT}, {"slot", slotStr, FIELD_STRING}});
-            return;
-        }
+        // Already fired for this slot today?
+        if (schedMins == firedSlots[si])
+            continue;
 
-        // Robot already cleaning — mark slot as fired so we don't retry every 30s
-        if (state.uiState != "UIMGR_STATE_IDLE" && state.uiState != "UIMGR_STATE_STANDBY") {
-            LOG("SCHED", "Robot busy (%s), skipping slot %s", state.uiState.c_str(), slotStr.c_str());
-            dataLogger.logGenericEvent("scheduler_skipped", {{"day", String(day), FIELD_INT},
-                                                             {"slot", slotStr, FIELD_STRING},
-                                                             {"reason", "busy", FIELD_STRING},
-                                                             {"state", state.uiState, FIELD_STRING}});
-            firedDay = day;
-            firedSlot = schedMins;
-            return;
-        }
+        // Build common log fields for this slot
+        String slotStr = String(schedMins / 60) + ":" + (schedMins % 60 < 10 ? "0" : "") + String(schedMins % 60);
 
-        LOG("SCHED", "Triggering scheduled clean (day=%d slot=%s)", day, slotStr.c_str());
-        dataLogger.logGenericEvent("scheduler_trigger",
-                                   {{"day", String(day), FIELD_INT}, {"slot", slotStr, FIELD_STRING}});
-
-        serial.clean("house", [this, day, slotStr](bool ok) {
-            LOG("SCHED", "Scheduled clean %s", ok ? "started" : "FAILED");
+        // Check robot state before triggering (uses cached state — no extra serial command)
+        serial.getState([this, si, day, schedMins, slotStr](bool ok, const RobotState& state) {
             if (!ok) {
-                dataLogger.logGenericEvent("scheduler_trigger_failed",
+                LOG("SCHED", "GetState failed, cannot check robot state for slot %s", slotStr.c_str());
+                dataLogger.logGenericEvent("scheduler_state_error",
                                            {{"day", String(day), FIELD_INT}, {"slot", slotStr, FIELD_STRING}});
+                return;
             }
+
+            // Robot already cleaning — mark slot as fired so we don't retry every 30s
+            if (state.uiState != "UIMGR_STATE_IDLE" && state.uiState != "UIMGR_STATE_STANDBY") {
+                LOG("SCHED", "Robot busy (%s), skipping slot %s", state.uiState.c_str(), slotStr.c_str());
+                dataLogger.logGenericEvent("scheduler_skipped", {{"day", String(day), FIELD_INT},
+                                                                 {"slot", slotStr, FIELD_STRING},
+                                                                 {"reason", "busy", FIELD_STRING},
+                                                                 {"state", state.uiState, FIELD_STRING}});
+                firedSlots[si] = schedMins;
+                return;
+            }
+
+            LOG("SCHED", "Triggering scheduled clean (day=%d slot=%d %s)", day, si, slotStr.c_str());
+            dataLogger.logGenericEvent("scheduler_trigger",
+                                       {{"day", String(day), FIELD_INT}, {"slot", slotStr, FIELD_STRING}});
+
+            serial.clean("house", [this, si, day, slotStr](bool ok) {
+                LOG("SCHED", "Scheduled clean %s", ok ? "started" : "FAILED");
+                if (!ok) {
+                    dataLogger.logGenericEvent("scheduler_trigger_failed",
+                                               {{"day", String(day), FIELD_INT}, {"slot", slotStr, FIELD_STRING}});
+                }
+            });
+
+            firedSlots[si] = schedMins;
         });
 
-        firedDay = day;
-        firedSlot = schedMins;
-    });
+        // Only trigger one slot per tick — let the next tick handle the second slot
+        // if both happen to fall in the same window (unlikely but safe)
+        return;
+    }
 }

--- a/firmware/src/scheduler.h
+++ b/firmware/src/scheduler.h
@@ -28,9 +28,10 @@ private:
     NeatoSerial& serial;
     DataLogger& dataLogger;
 
-    // Duplicate trigger guard: remember the last slot we fired
+    // Duplicate trigger guard: remember fired slots per day.
+    // Key = day * SCHEDULE_SLOTS_PER_DAY + slotIndex, value = minutes-since-midnight.
     int firedDay = -1;
-    int firedSlot = -1; // Minutes-since-midnight of the scheduled slot
+    int firedSlots[SCHEDULE_SLOTS_PER_DAY] = {-1, -1}; // Minutes-since-midnight per slot index
 
     // Convert C library tm_wday (Sun=0..Sat=6) to our index (Mon=0..Sun=6)
     static int toSchedDay(int tmWday);

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -3,9 +3,14 @@
 // Day-name labels for JSON responses (Mon=0 .. Sun=6)
 static const char *DAY_NAMES[SCHEDULE_DAYS] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
 
-// Build NVS key for a per-day schedule field: "s0h", "s0m", "s0on", etc.
-static String schedKey(int day, const char *suffix) {
-    return "s" + String(day) + suffix;
+// Build NVS key for a per-day, per-slot schedule field.
+// Slot 0 (legacy): "s0h", "s0m", "s0on" (backwards compatible with single-slot firmware)
+// Slot 1: "s0h1", "s0m1", "s0on1"
+static String schedKey(int day, int slot, const char *suffix) {
+    String key = "s" + String(day) + suffix;
+    if (slot > 0)
+        key += String(slot);
+    return key;
 }
 
 SettingsManager::SettingsManager(Preferences& prefs) : prefs(prefs) {}
@@ -65,9 +70,11 @@ void SettingsManager::load() {
     current.ntfyOnDocking = prefs.getBool(NVS_KEY_NTFY_ON_DOCK, true);
     current.scheduleEnabled = prefs.getBool(NVS_KEY_SCHED_ENABLED, false);
     for (int d = 0; d < SCHEDULE_DAYS; d++) {
-        current.sched[d].hour = prefs.getInt(schedKey(d, "h").c_str(), 0);
-        current.sched[d].minute = prefs.getInt(schedKey(d, "m").c_str(), 0);
-        current.sched[d].on = prefs.getBool(schedKey(d, "on").c_str(), false);
+        for (int s = 0; s < SCHEDULE_SLOTS_PER_DAY; s++) {
+            current.sched[d].slots[s].hour = prefs.getInt(schedKey(d, s, "h").c_str(), 0);
+            current.sched[d].slots[s].minute = prefs.getInt(schedKey(d, s, "m").c_str(), 0);
+            current.sched[d].slots[s].on = prefs.getBool(schedKey(d, s, "on").c_str(), false);
+        }
     }
 }
 
@@ -90,9 +97,11 @@ void SettingsManager::save() {
     prefs.putBool(NVS_KEY_NTFY_ON_DOCK, current.ntfyOnDocking);
     prefs.putBool(NVS_KEY_SCHED_ENABLED, current.scheduleEnabled);
     for (int d = 0; d < SCHEDULE_DAYS; d++) {
-        prefs.putInt(schedKey(d, "h").c_str(), current.sched[d].hour);
-        prefs.putInt(schedKey(d, "m").c_str(), current.sched[d].minute);
-        prefs.putBool(schedKey(d, "on").c_str(), current.sched[d].on);
+        for (int s = 0; s < SCHEDULE_SLOTS_PER_DAY; s++) {
+            prefs.putInt(schedKey(d, s, "h").c_str(), current.sched[d].slots[s].hour);
+            prefs.putInt(schedKey(d, s, "m").c_str(), current.sched[d].slots[s].minute);
+            prefs.putBool(schedKey(d, s, "on").c_str(), current.sched[d].slots[s].on);
+        }
     }
 }
 
@@ -260,17 +269,20 @@ ApplyResult SettingsManager::apply(const String& json) {
     }
 
     for (int d = 0; d < SCHEDULE_DAYS; d++) { // NOLINT(modernize-loop-convert) index needed for DAY_NAMES[d]
-        SchedDay& cur = current.sched[d];
-        const SchedDay& inc = incoming.sched[d];
-        if (inc.hour != cur.hour || inc.minute != cur.minute || inc.on != cur.on) {
-            // Validate hour/minute ranges
-            if (inc.hour < 0 || inc.hour > 23 || inc.minute < 0 || inc.minute > 59)
-                return APPLY_INVALID;
-            cur.hour = inc.hour;
-            cur.minute = inc.minute;
-            cur.on = inc.on;
-            changed = true;
-            LOG("SETTINGS", "Sched %s -> %02d:%02d %s", DAY_NAMES[d], cur.hour, cur.minute, cur.on ? "on" : "off");
+        for (int s = 0; s < SCHEDULE_SLOTS_PER_DAY; s++) {
+            SchedSlot& cur = current.sched[d].slots[s];
+            const SchedSlot& inc = incoming.sched[d].slots[s];
+            if (inc.hour != cur.hour || inc.minute != cur.minute || inc.on != cur.on) {
+                // Validate hour/minute ranges
+                if (inc.hour < 0 || inc.hour > 23 || inc.minute < 0 || inc.minute > 59)
+                    return APPLY_INVALID;
+                cur.hour = inc.hour;
+                cur.minute = inc.minute;
+                cur.on = inc.on;
+                changed = true;
+                LOG("SETTINGS", "Sched %s slot %d -> %02d:%02d %s", DAY_NAMES[d], s, cur.hour, cur.minute,
+                    cur.on ? "on" : "off");
+            }
         }
     }
 
@@ -308,10 +320,16 @@ std::vector<Field> Settings::toFields() const {
             {"scheduleEnabled", scheduleEnabled ? "true" : "false", FIELD_BOOL},
     };
     for (int d = 0; d < SCHEDULE_DAYS; d++) {
-        String prefix = "sched" + String(d);
-        f.push_back({prefix + "Hour", String(sched[d].hour), FIELD_INT});
-        f.push_back({prefix + "Min", String(sched[d].minute), FIELD_INT});
-        f.push_back({prefix + "On", sched[d].on ? "true" : "false", FIELD_BOOL});
+        for (int s = 0; s < SCHEDULE_SLOTS_PER_DAY; s++) {
+            // Slot 0: "sched0Hour", "sched0Min", "sched0On" (backwards compatible)
+            // Slot 1: "sched0Slot1Hour", "sched0Slot1Min", "sched0Slot1On"
+            String prefix = "sched" + String(d);
+            if (s > 0)
+                prefix += "Slot" + String(s);
+            f.push_back({prefix + "Hour", String(sched[d].slots[s].hour), FIELD_INT});
+            f.push_back({prefix + "Min", String(sched[d].slots[s].minute), FIELD_INT});
+            f.push_back({prefix + "On", sched[d].slots[s].on ? "true" : "false", FIELD_BOOL});
+        }
     }
     return f;
 }
@@ -389,18 +407,22 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
         applied = true;
     }
     for (int d = 0; d < SCHEDULE_DAYS; d++) { // NOLINT(modernize-loop-convert) index needed for field name prefix
-        String prefix = "sched" + String(d);
-        if ((f = findField(fields, (prefix + "Hour").c_str())) && f->type == FIELD_INT) {
-            sched[d].hour = f->value.toInt();
-            applied = true;
-        }
-        if ((f = findField(fields, (prefix + "Min").c_str())) && f->type == FIELD_INT) {
-            sched[d].minute = f->value.toInt();
-            applied = true;
-        }
-        if ((f = findField(fields, (prefix + "On").c_str())) && f->type == FIELD_BOOL) {
-            sched[d].on = (f->value == "true");
-            applied = true;
+        for (int s = 0; s < SCHEDULE_SLOTS_PER_DAY; s++) {
+            String prefix = "sched" + String(d);
+            if (s > 0)
+                prefix += "Slot" + String(s);
+            if ((f = findField(fields, (prefix + "Hour").c_str())) && f->type == FIELD_INT) {
+                sched[d].slots[s].hour = f->value.toInt();
+                applied = true;
+            }
+            if ((f = findField(fields, (prefix + "Min").c_str())) && f->type == FIELD_INT) {
+                sched[d].slots[s].minute = f->value.toInt();
+                applied = true;
+            }
+            if ((f = findField(fields, (prefix + "On").c_str())) && f->type == FIELD_BOOL) {
+                sched[d].slots[s].on = (f->value == "true");
+                applied = true;
+            }
         }
     }
 

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -7,11 +7,16 @@
 #include "config.h"
 #include "json_fields.h"
 
-// Per-day schedule slot (Mon=0 .. Sun=6)
-struct SchedDay {
+// Single schedule time slot
+struct SchedSlot {
     int hour = 0; // 0-23
     int minute = 0; // 0-59
     bool on = false; // true = house clean at this time
+};
+
+// Per-day schedule (Mon=0 .. Sun=6), two slots per day
+struct SchedDay {
+    SchedSlot slots[SCHEDULE_SLOTS_PER_DAY];
 };
 
 // All user-configurable settings — flat struct, serializable to/from JSON

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -267,8 +267,9 @@ const state = {
     filterChange: 2592000,
     brushChange: 2592000,
     dirtBin: 30,
-    // Schedule (Mon=0..Sun=6)
+    // Schedule (Mon=0..Sun=6), two slots per day
     scheduleEnabled: true,
+    // Slot 0 (primary)
     sched0Hour: 9,
     sched0Min: 0,
     sched0On: true, // Mon
@@ -290,6 +291,28 @@ const state = {
     sched6Hour: 0,
     sched6Min: 0,
     sched6On: false, // Sun
+    // Slot 1 (secondary)
+    sched0Slot1Hour: 15,
+    sched0Slot1Min: 0,
+    sched0Slot1On: true, // Mon afternoon
+    sched1Slot1Hour: 15,
+    sched1Slot1Min: 0,
+    sched1Slot1On: true, // Tue afternoon
+    sched2Slot1Hour: 15,
+    sched2Slot1Min: 0,
+    sched2Slot1On: true, // Wed afternoon
+    sched3Slot1Hour: 15,
+    sched3Slot1Min: 0,
+    sched3Slot1On: true, // Thu afternoon
+    sched4Slot1Hour: 15,
+    sched4Slot1Min: 0,
+    sched4Slot1On: true, // Fri afternoon
+    sched5Slot1Hour: 0,
+    sched5Slot1Min: 0,
+    sched5Slot1On: false, // Sat
+    sched6Slot1Hour: 0,
+    sched6Slot1Min: 0,
+    sched6Slot1On: false, // Sun
     ...merged,
 };
 
@@ -721,6 +744,9 @@ const routes = {
             s[`sched${d}Hour`] = state[`sched${d}Hour`];
             s[`sched${d}Min`] = state[`sched${d}Min`];
             s[`sched${d}On`] = state[`sched${d}On`];
+            s[`sched${d}Slot1Hour`] = state[`sched${d}Slot1Hour`];
+            s[`sched${d}Slot1Min`] = state[`sched${d}Slot1Min`];
+            s[`sched${d}Slot1On`] = state[`sched${d}Slot1On`];
         }
         jsonResponse(res, s);
     },
@@ -1029,6 +1055,9 @@ const handleRequest = async (req, res) => {
                 if (data[`sched${d}Hour`] !== undefined) state[`sched${d}Hour`] = data[`sched${d}Hour`];
                 if (data[`sched${d}Min`] !== undefined) state[`sched${d}Min`] = data[`sched${d}Min`];
                 if (data[`sched${d}On`] !== undefined) state[`sched${d}On`] = data[`sched${d}On`];
+                if (data[`sched${d}Slot1Hour`] !== undefined) state[`sched${d}Slot1Hour`] = data[`sched${d}Slot1Hour`];
+                if (data[`sched${d}Slot1Min`] !== undefined) state[`sched${d}Slot1Min`] = data[`sched${d}Slot1Min`];
+                if (data[`sched${d}Slot1On`] !== undefined) state[`sched${d}Slot1On`] = data[`sched${d}Slot1On`];
             }
             if (pinsChanged || hostnameChanged) {
                 setTimeout(() => {
@@ -1062,6 +1091,9 @@ const handleRequest = async (req, res) => {
                 s[`sched${d}Hour`] = state[`sched${d}Hour`];
                 s[`sched${d}Min`] = state[`sched${d}Min`];
                 s[`sched${d}On`] = state[`sched${d}On`];
+                s[`sched${d}Slot1Hour`] = state[`sched${d}Slot1Hour`];
+                s[`sched${d}Slot1Min`] = state[`sched${d}Slot1Min`];
+                s[`sched${d}Slot1On`] = state[`sched${d}Slot1On`];
             }
             return jsonResponse(res, s);
         } catch {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -163,12 +163,7 @@ export const api = {
     importSession: (file: File, onProgress: (pct: number) => void) => importSession(file, onProgress),
     uploadFirmware: (file: File, md5: string, onProgress: (pct: number) => void) =>
         uploadFirmware(file, md5, onProgress),
-    setScheduleDay: (day: number, hour: number, minute: number, on: boolean) =>
-        put<SettingsData>("/api/settings", {
-            [`sched${day}Hour`]: hour,
-            [`sched${day}Min`]: minute,
-            [`sched${day}On`]: on,
-        }),
+    saveSchedule: (patch: Partial<SettingsData>) => put<SettingsData>("/api/settings", patch),
     setScheduleEnabled: (on: boolean) => put<SettingsData>("/api/settings", { scheduleEnabled: on }),
     getUserSettings: () => get<UserSettingsData>("/api/user-settings"),
     setUserSetting: (key: string, value: string) =>

--- a/frontend/src/hooks/use-dirty-guard.ts
+++ b/frontend/src/hooks/use-dirty-guard.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { useNavigate, usePath } from "../components/router";
+
+/**
+ * Prevents accidental navigation away from a page with unsaved changes.
+ * - Intercepts browser close/reload via beforeunload
+ * - Intercepts browser back/forward via hashchange (SPA hash routing)
+ * - Wraps in-app navigation with a confirm dialog when dirty
+ *
+ * Returns guardedNavigate (use instead of navigate), the discard dialog state,
+ * and a handler to call when the user confirms discarding.
+ */
+export function useDirtyGuard(isDirty: boolean) {
+    const navigate = useNavigate();
+    const currentPath = usePath();
+    const dirtyRef = useRef(false);
+    dirtyRef.current = isDirty;
+
+    // Remember our path so we can restore hash on blocked back/forward
+    const pathRef = useRef(currentPath);
+    pathRef.current = currentPath;
+
+    const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+    const pendingNav = useRef<string | null>(null);
+
+    // Browser close/reload guard
+    useEffect(() => {
+        const handler = (e: BeforeUnloadEvent) => {
+            if (dirtyRef.current) e.preventDefault();
+        };
+        window.addEventListener("beforeunload", handler);
+        return () => window.removeEventListener("beforeunload", handler);
+    }, []);
+
+    // Browser back/forward guard - intercept hashchange when dirty
+    useEffect(() => {
+        const handler = () => {
+            if (!dirtyRef.current) return;
+
+            // Hash changed while dirty - read where the browser wants to go
+            const newHash = location.hash.replace(/^#/, "") || "/";
+            const target = newHash.startsWith("/") ? newHash : `/${newHash}`;
+
+            // Restore our current path in the URL (block the navigation)
+            const ourHash = `#${pathRef.current}`;
+            if (location.hash !== ourHash) {
+                history.replaceState(null, "", ourHash);
+            }
+
+            // Show confirm dialog with the intended destination
+            pendingNav.current = target;
+            setShowDiscardConfirm(true);
+        };
+        window.addEventListener("hashchange", handler);
+        return () => window.removeEventListener("hashchange", handler);
+    }, []);
+
+    // In-app navigation guard
+    const guardedNavigate = useCallback(
+        (to: string) => {
+            if (isDirty) {
+                pendingNav.current = to;
+                setShowDiscardConfirm(true);
+            } else {
+                navigate(to);
+            }
+        },
+        [isDirty, navigate],
+    );
+
+    // Called when user confirms discard
+    const handleDiscard = useCallback(() => {
+        setShowDiscardConfirm(false);
+        if (pendingNav.current) {
+            navigate(pendingNav.current);
+            pendingNav.current = null;
+        }
+    }, [navigate]);
+
+    return {
+        guardedNavigate,
+        showDiscardConfirm,
+        setShowDiscardConfirm,
+        handleDiscard,
+    };
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2080,6 +2080,10 @@ body {
     opacity: 0.5;
 }
 
+.history-session-stats .history-session-battery {
+    display: none;
+}
+
 .history-session-chevron {
     font-size: 20px;
     color: var(--text-muted);
@@ -2304,15 +2308,125 @@ body {
     gap: 8px;
 }
 
-.schedule-day-row {
+.sched-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 12px 16px;
+    padding: 10px 14px;
     border: 1px solid var(--border);
     border-radius: 12px;
     background: var(--surface);
-    gap: 10px;
+    gap: 8px;
+}
+
+.sched-day-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+    min-width: 30px;
+    flex-shrink: 0;
+}
+
+.sched-day-label.off {
+    color: var(--text-muted);
+}
+
+.sched-slots {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    justify-content: flex-end;
+}
+
+.sched-time-input {
+    width: 56px;
+    padding: 6px 4px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--card-bg);
+    color: var(--text);
+    font-size: 14px;
+    font-weight: 600;
+    font-family: inherit;
+    text-align: center;
+    outline: none;
+    -webkit-appearance: none;
+    font-variant-numeric: tabular-nums;
+}
+
+.sched-time-input:focus {
+    border-color: var(--accent);
+}
+
+.sched-time-input.invalid {
+    border-color: var(--red);
+    color: var(--red);
+}
+
+.sched-time-input:disabled {
+    opacity: 0.5;
+}
+
+.sched-slot2-wrap {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.sched-add-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 7px;
+    border: 1px dashed var(--text-muted);
+    background: none;
+    color: var(--text-muted);
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    flex-shrink: 0;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.sched-add-btn:active {
+    opacity: 0.6;
+}
+
+.sched-add-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.sched-remove-btn {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    flex-shrink: 0;
+    opacity: 0.5;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.sched-remove-btn:active {
+    opacity: 1;
+}
+
+.sched-remove-btn:disabled {
+    cursor: default;
 }
 
 .schedule-day-left {
@@ -2361,70 +2475,16 @@ body {
     background: var(--green);
 }
 
-.schedule-day-name {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text);
-    min-width: 32px;
+.schedule-page .settings-save-btn {
+    margin-top: 20px;
 }
 
-.schedule-day-name.off {
-    color: var(--text-muted);
-}
-
-.schedule-day-right {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex: 1;
-    justify-content: flex-end;
-}
-
-.schedule-time-inputs {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-}
-
-.schedule-time-inputs span {
-    display: flex;
-}
-
-.schedule-time-inputs svg {
-    width: 14px;
-    height: 14px;
-    opacity: 0.4;
-}
-
-.schedule-time-select {
-    width: 48px;
-    padding: 6px 4px;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--card-bg);
-    color: var(--text);
-    font-size: 13px;
+.schedule-tz-hint {
+    font-size: 12px;
     font-weight: 500;
-    font-family: inherit;
-    text-align: center;
-    appearance: none;
-    -webkit-appearance: none;
-    cursor: pointer;
-    outline: none;
-}
-
-.schedule-time-select:focus {
-    border-color: var(--accent);
-}
-
-.schedule-time-colon {
-    font-size: 14px;
-    font-weight: 600;
     color: var(--text-muted);
-}
-
-.schedule-day-row.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
+    text-align: center;
+    margin-bottom: 12px;
 }
 
 /* Manual control page */
@@ -2633,6 +2693,10 @@ body {
 /* Tablets and desktop */
 
 @media (min-width: 600px) {
+    .history-session-stats .history-session-battery {
+        display: flex;
+    }
+
     body {
         max-width: 600px;
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -40,7 +40,9 @@ export interface SystemData {
     tz: string;
 }
 
-// Per-day schedule fields: sched{0-6}Hour, sched{0-6}Min, sched{0-6}On (Mon=0..Sun=6)
+// Per-day schedule fields (Mon=0..Sun=6), two slots per day.
+// Slot 0 (primary):   sched{0-6}Hour, sched{0-6}Min, sched{0-6}On
+// Slot 1 (secondary): sched{0-6}Slot1Hour, sched{0-6}Slot1Min, sched{0-6}Slot1On
 export interface SettingsData {
     tz: string;
     logLevel: number; // 0=off, 1=info, 2=debug
@@ -60,6 +62,7 @@ export interface SettingsData {
     ntfyOnAlert: boolean; // Notify on robot alert (UI_ALERT_*, code 201-242)
     ntfyOnDocking: boolean; // Notify when robot returns to base
     scheduleEnabled: boolean;
+    // Slot 0 (primary)
     sched0Hour: number;
     sched0Min: number;
     sched0On: boolean;
@@ -81,6 +84,28 @@ export interface SettingsData {
     sched6Hour: number;
     sched6Min: number;
     sched6On: boolean;
+    // Slot 1 (secondary)
+    sched0Slot1Hour: number;
+    sched0Slot1Min: number;
+    sched0Slot1On: boolean;
+    sched1Slot1Hour: number;
+    sched1Slot1Min: number;
+    sched1Slot1On: boolean;
+    sched2Slot1Hour: number;
+    sched2Slot1Min: number;
+    sched2Slot1On: boolean;
+    sched3Slot1Hour: number;
+    sched3Slot1Min: number;
+    sched3Slot1On: boolean;
+    sched4Slot1Hour: number;
+    sched4Slot1Min: number;
+    sched4Slot1On: boolean;
+    sched5Slot1Hour: number;
+    sched5Slot1Min: number;
+    sched5Slot1On: boolean;
+    sched6Slot1Hour: number;
+    sched6Slot1Min: number;
+    sched6Slot1On: boolean;
 }
 
 export interface UserSettingsData {

--- a/frontend/src/views/history/list.tsx
+++ b/frontend/src/views/history/list.tsx
@@ -44,17 +44,9 @@ function SessionCard({ session, summary, filename, index, active, onSelect, onDe
                             </span>
                             <span>{summary.distanceTraveled.toFixed(1)}m</span>
                             <span>{summary.areaCovered.toFixed(1)}m&sup2;</span>
-                            <span>
+                            <span class="history-session-battery">
                                 <Icon svg={boltSvg} />
                                 {session?.battery ?? "?"}% &rarr; {summary.batteryEnd ?? "?"}%
-                            </span>
-                        </div>
-                    )}
-                    {active && !summary && (
-                        <div class="history-session-stats">
-                            <span>
-                                <Icon svg={boltSvg} />
-                                {session?.battery ?? "?"}%
                             </span>
                         </div>
                     )}

--- a/frontend/src/views/schedule.tsx
+++ b/frontend/src/views/schedule.tsx
@@ -1,62 +1,145 @@
-import { useCallback, useEffect, useState } from "preact/hooks";
+import type { JSX } from "preact";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { api } from "../api";
 import backSvg from "../assets/icons/back.svg?raw";
-import clockSvg from "../assets/icons/clock.svg?raw";
+import { ConfirmDialog } from "../components/confirm-dialog";
 import { ErrorBannerStack, useErrorStack } from "../components/error-banner";
 import { Icon } from "../components/icon";
-import { useNavigate } from "../components/router";
+import { useDirtyGuard } from "../hooks/use-dirty-guard";
 import { useFetch } from "../hooks/use-fetch";
 import type { SettingsData } from "../types";
+import { findPresetLabel } from "./settings/helpers";
 
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const SLOTS_PER_DAY = 2;
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
 
-interface DayState {
+interface SlotState {
     hour: number;
     minute: number;
     on: boolean;
 }
 
+interface DayState {
+    slots: SlotState[];
+}
+
 type SchedDay = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-type SchedHourKey = `sched${SchedDay}Hour`;
-type SchedMinKey = `sched${SchedDay}Min`;
-type SchedOnKey = `sched${SchedDay}On`;
 
 function readDays(s: SettingsData): DayState[] {
     const days: DayState[] = [];
     for (let d = 0; d < 7; d++) {
         const day = d as SchedDay;
-        days.push({
-            hour: s[`sched${day}Hour` as SchedHourKey] ?? 0,
-            minute: s[`sched${day}Min` as SchedMinKey] ?? 0,
-            on: s[`sched${day}On` as SchedOnKey] ?? false,
-        });
+        const slot0: SlotState = {
+            hour: (s[`sched${day}Hour` as keyof SettingsData] as number) ?? 0,
+            minute: (s[`sched${day}Min` as keyof SettingsData] as number) ?? 0,
+            on: (s[`sched${day}On` as keyof SettingsData] as boolean) ?? false,
+        };
+        const slot1: SlotState = {
+            hour: (s[`sched${day}Slot1Hour` as keyof SettingsData] as number) ?? 0,
+            minute: (s[`sched${day}Slot1Min` as keyof SettingsData] as number) ?? 0,
+            on: (s[`sched${day}Slot1On` as keyof SettingsData] as boolean) ?? false,
+        };
+        days.push({ slots: [slot0, slot1] });
     }
     return days;
 }
 
-function padTime(n: number): string {
-    return n.toString().padStart(2, "0");
+function daysToDrafts(days: DayState[]): string[][] {
+    return days.map((d) => d.slots.map((s) => fmtTime(s.hour, s.minute)));
+}
+
+function buildSchedulePatch(days: DayState[], server: DayState[]): Partial<SettingsData> {
+    const patch: Record<string, number | boolean> = {};
+    for (let d = 0; d < 7; d++) {
+        for (let s = 0; s < SLOTS_PER_DAY; s++) {
+            const cur = days[d].slots[s];
+            const srv = server[d].slots[s];
+            const prefix = s === 0 ? `sched${d}` : `sched${d}Slot${s}`;
+            if (cur.hour !== srv.hour) patch[`${prefix}Hour`] = cur.hour;
+            if (cur.minute !== srv.minute) patch[`${prefix}Min`] = cur.minute;
+            if (cur.on !== srv.on) patch[`${prefix}On`] = cur.on;
+        }
+    }
+    return patch as Partial<SettingsData>;
+}
+
+function fmtTime(h: number, m: number): string {
+    return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+}
+
+function parseTime(value: string): { hour: number; minute: number } | null {
+    const match = value.match(TIME_RE);
+    if (!match) return null;
+    return { hour: Number.parseInt(match[1], 10), minute: Number.parseInt(match[2], 10) };
+}
+
+function tzLabel(tz: string): string {
+    const preset = findPresetLabel(tz);
+    if (preset) return preset;
+    const match = tz.match(/^([A-Z]{2,5})/);
+    return match ? match[1] : tz;
+}
+
+// Validate all enabled time drafts. Returns set of "day-slot" keys that are invalid.
+function validateDrafts(days: DayState[], drafts: string[][]): Set<string> {
+    const invalid = new Set<string>();
+    for (let d = 0; d < 7; d++) {
+        for (let s = 0; s < SLOTS_PER_DAY; s++) {
+            if (days[d].slots[s].on && !parseTime(drafts[d][s])) {
+                invalid.add(`${d}-${s}`);
+            }
+        }
+    }
+    return invalid;
+}
+
+// Apply parsed draft times back into day state (only for enabled, valid slots)
+function applyDrafts(days: DayState[], drafts: string[][]): DayState[] {
+    return days.map((day, d) => ({
+        slots: day.slots.map((slot, s) => {
+            if (!slot.on) return slot;
+            const parsed = parseTime(drafts[d][s]);
+            if (!parsed) return slot;
+            return { ...slot, hour: parsed.hour, minute: parsed.minute };
+        }),
+    }));
 }
 
 export function ScheduleView() {
-    const navigate = useNavigate();
     const [errors, errorStack] = useErrorStack();
-    const [saving, setSaving] = useState<number | null>(null); // day index being saved
-    const [masterSaving, setMasterSaving] = useState(false);
+    const [saving, setSaving] = useState(false);
 
-    // Fetch settings on mount
     const { data: settings, loading, error: fetchError } = useFetch(api.getSettings);
 
-    // Local state — seeded from fetch, then locally managed
     const [enabled, setEnabled] = useState(false);
+    const [tz, setTz] = useState("UTC0");
     const [days, setDays] = useState<DayState[]>(() =>
-        Array.from({ length: 7 }, () => ({ hour: 0, minute: 0, on: false })),
+        Array.from({ length: 7 }, () => ({
+            slots: Array.from({ length: SLOTS_PER_DAY }, () => ({ hour: 0, minute: 0, on: false })),
+        })),
     );
+
+    // Draft strings for time inputs (free-form text, validated at save)
+    const [drafts, setDrafts] = useState<string[][]>(() => Array.from({ length: 7 }, () => ["00:00", "00:00"]));
+
+    // Set of "day-slot" keys with validation errors (populated at save time)
+    const [invalidSlots, setInvalidSlots] = useState<Set<string>>(new Set());
+
+    // Server-confirmed state for dirty detection
+    const serverDays = useRef<DayState[]>(days);
+    const serverEnabled = useRef(false);
 
     useEffect(() => {
         if (settings) {
+            const d = readDays(settings);
             setEnabled(settings.scheduleEnabled);
-            setDays(readDays(settings));
+            serverEnabled.current = settings.scheduleEnabled;
+            setTz(settings.tz);
+            setDays(d);
+            setDrafts(daysToDrafts(d));
+            serverDays.current = d;
+            setInvalidSlots(new Set());
         }
     }, [settings]);
 
@@ -64,40 +147,97 @@ export function ScheduleView() {
         if (fetchError) errorStack.push(fetchError);
     }, [fetchError]);
 
-    // Toggle master enable — apply immediately
-    const handleToggleMaster = useCallback(() => {
-        const newVal = !enabled;
-        setEnabled(newVal);
-        setMasterSaving(true);
-        api.setScheduleEnabled(newVal)
-            .catch((e: unknown) => {
-                setEnabled(!newVal); // revert on failure
-                errorStack.push(e instanceof Error ? e.message : "Failed to update schedule");
-            })
-            .finally(() => setMasterSaving(false));
-    }, [enabled, errorStack]);
+    // Dirty = toggle changed, or any draft text differs from server
+    const isDirty = enabled !== serverEnabled.current || !draftsMatchDays(drafts, days, serverDays.current);
 
-    // Update a single day and send to server immediately
-    const applyDay = useCallback(
-        (day: number, patch: Partial<DayState>) => {
-            const prev = days[day];
-            const updated = { ...prev, ...patch };
-            setDays((cur) => cur.map((d, i) => (i === day ? updated : d)));
-            setSaving(day);
-            api.setScheduleDay(day, updated.hour, updated.minute, updated.on)
-                .catch((e: unknown) => {
-                    setDays((cur) => cur.map((d, i) => (i === day ? prev : d))); // revert
-                    errorStack.push(e instanceof Error ? e.message : `Failed to save ${DAY_NAMES[day]}`);
-                })
-                .finally(() => setSaving(null));
-        },
-        [days, errorStack],
-    );
+    const { guardedNavigate, showDiscardConfirm, setShowDiscardConfirm, handleDiscard } = useDirtyGuard(isDirty);
+
+    // Local-only state changes (no API call)
+    const updateSlot = useCallback((day: number, slot: number, patch: Partial<SlotState>) => {
+        setDays((cur) =>
+            cur.map((d, i) =>
+                i === day ? { slots: d.slots.map((s, si) => (si === slot ? { ...s, ...patch } : s)) } : d,
+            ),
+        );
+        // When adding slot 2, seed draft with default time
+        if (patch.on === true && patch.hour !== undefined) {
+            setDrafts((cur) =>
+                cur.map((r, i) =>
+                    i === day ? r.map((v, si) => (si === slot ? fmtTime(patch.hour ?? 0, patch.minute ?? 0) : v)) : r,
+                ),
+            );
+        }
+    }, []);
+
+    const updateDraft = useCallback((day: number, slot: number, raw: string) => {
+        // Auto-insert colon: "0930" -> "09:30"
+        let value = raw;
+        if (/^\d{4}$/.test(value)) {
+            value = `${value.slice(0, 2)}:${value.slice(2)}`;
+        }
+        setDrafts((cur) => cur.map((r, i) => (i === day ? r.map((v, si) => (si === slot ? value : v)) : r)));
+        // Clear validation error for this slot on edit
+        setInvalidSlots((cur) => {
+            const key = `${day}-${slot}`;
+            if (!cur.has(key)) return cur;
+            const next = new Set(cur);
+            next.delete(key);
+            return next;
+        });
+    }, []);
+
+    // Single batched save with validation
+    const handleSave = useCallback(() => {
+        // Apply drafts to get final day state
+        const finalDays = applyDrafts(days, drafts);
+
+        // Validate all enabled slots
+        const invalid = validateDrafts(finalDays, drafts);
+        if (invalid.size > 0) {
+            setInvalidSlots(invalid);
+            errorStack.push("Fix invalid times before saving (use HH:MM format, 00:00-23:59)");
+            return;
+        }
+
+        const patch: Partial<SettingsData> = {
+            ...buildSchedulePatch(finalDays, serverDays.current),
+        };
+        if (enabled !== serverEnabled.current) {
+            patch.scheduleEnabled = enabled;
+        }
+
+        setSaving(true);
+        setInvalidSlots(new Set());
+        api.saveSchedule(patch)
+            .then((res) => {
+                const d = readDays(res);
+                serverDays.current = d;
+                serverEnabled.current = res.scheduleEnabled;
+                setDays(d);
+                setDrafts(daysToDrafts(d));
+                setEnabled(res.scheduleEnabled);
+            })
+            .catch((e: unknown) => {
+                errorStack.push(e instanceof Error ? e.message : "Failed to save schedule");
+            })
+            .finally(() => setSaving(false));
+    }, [days, drafts, enabled, errorStack]);
+
+    const onKeyDown = useCallback((e: JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.currentTarget.blur();
+        }
+    }, []);
 
     return (
         <>
             <div class="header">
-                <button type="button" class="header-back-btn" onClick={() => navigate("/settings")} aria-label="Back">
+                <button
+                    type="button"
+                    class="header-back-btn"
+                    onClick={() => guardedNavigate("/settings")}
+                    aria-label="Back"
+                >
                     <Icon svg={backSvg} />
                 </button>
                 <h1>Schedule</h1>
@@ -119,84 +259,126 @@ export function ScheduleView() {
                             </div>
                             <button
                                 type="button"
-                                class={`settings-toggle${enabled ? " on" : ""}${masterSaving ? " pending" : ""}`}
-                                onClick={handleToggleMaster}
-                                disabled={masterSaving}
+                                class={`settings-toggle${enabled ? " on" : ""}`}
+                                onClick={() => setEnabled((v) => !v)}
                                 aria-label="Toggle schedule"
                             />
                         </div>
 
-                        {/* Day entries */}
+                        <div class="schedule-tz-hint">Times are in {tzLabel(tz)}</div>
+
+                        {/* Day rows */}
                         <div class="schedule-days">
                             {days.map((day, i) => {
-                                const isSaving = saving === i;
+                                const s0 = day.slots[0];
+                                const s1 = day.slots[1];
+
                                 return (
-                                    <div key={i} class={`schedule-day-row${isSaving ? " pending" : ""}`}>
-                                        <div class="schedule-day-left">
-                                            <button
-                                                type="button"
-                                                class={`schedule-day-toggle${day.on ? " on" : ""}`}
-                                                onClick={() => applyDay(i, { on: !day.on })}
-                                                disabled={isSaving}
-                                                aria-label={`Toggle ${DAY_NAMES[i]}`}
-                                            />
-                                            <span class={`schedule-day-name${day.on ? "" : " off"}`}>
-                                                {DAY_NAMES[i]}
-                                            </span>
-                                        </div>
-                                        <div class="schedule-day-right">
-                                            {day.on && (
-                                                <div class="schedule-time-inputs">
-                                                    <Icon svg={clockSvg} />
-                                                    <select
-                                                        class="schedule-time-select"
-                                                        value={day.hour}
-                                                        onChange={(e) =>
-                                                            applyDay(i, {
-                                                                hour: Number.parseInt(
-                                                                    (e.target as HTMLSelectElement).value,
-                                                                    10,
-                                                                ),
-                                                            })
+                                    <div key={i} class="sched-row">
+                                        <button
+                                            type="button"
+                                            class={`schedule-day-toggle${s0.on ? " on" : ""}`}
+                                            onClick={() => updateSlot(i, 0, { on: !s0.on })}
+                                            aria-label={`Toggle ${DAY_NAMES[i]}`}
+                                        />
+                                        <span class={`sched-day-label${s0.on ? "" : " off"}`}>{DAY_NAMES[i]}</span>
+
+                                        <div class="sched-slots">
+                                            {s0.on && (
+                                                <input
+                                                    type="text"
+                                                    inputMode="numeric"
+                                                    class={`sched-time-input${invalidSlots.has(`${i}-0`) ? " invalid" : ""}`}
+                                                    value={drafts[i][0]}
+                                                    maxLength={5}
+                                                    placeholder="HH:MM"
+                                                    onInput={(e) =>
+                                                        updateDraft(i, 0, (e.target as HTMLInputElement).value)
+                                                    }
+                                                    onKeyDown={onKeyDown}
+                                                />
+                                            )}
+
+                                            {s0.on && s1.on && (
+                                                <div class="sched-slot2-wrap">
+                                                    <input
+                                                        type="text"
+                                                        inputMode="numeric"
+                                                        class={`sched-time-input${invalidSlots.has(`${i}-1`) ? " invalid" : ""}`}
+                                                        value={drafts[i][1]}
+                                                        maxLength={5}
+                                                        placeholder="HH:MM"
+                                                        onInput={(e) =>
+                                                            updateDraft(i, 1, (e.target as HTMLInputElement).value)
                                                         }
-                                                        disabled={isSaving}
+                                                        onKeyDown={onKeyDown}
+                                                    />
+                                                    <button
+                                                        type="button"
+                                                        class="sched-remove-btn"
+                                                        onClick={() => updateSlot(i, 1, { on: false })}
+                                                        aria-label={`Remove ${DAY_NAMES[i]} second slot`}
                                                     >
-                                                        {Array.from({ length: 24 }, (_, h) => (
-                                                            <option key={h} value={h}>
-                                                                {padTime(h)}
-                                                            </option>
-                                                        ))}
-                                                    </select>
-                                                    <span class="schedule-time-colon">:</span>
-                                                    <select
-                                                        class="schedule-time-select"
-                                                        value={day.minute}
-                                                        onChange={(e) =>
-                                                            applyDay(i, {
-                                                                minute: Number.parseInt(
-                                                                    (e.target as HTMLSelectElement).value,
-                                                                    10,
-                                                                ),
-                                                            })
-                                                        }
-                                                        disabled={isSaving}
-                                                    >
-                                                        {Array.from({ length: 60 }, (_, m) => (
-                                                            <option key={m} value={m}>
-                                                                {padTime(m)}
-                                                            </option>
-                                                        ))}
-                                                    </select>
+                                                        x
+                                                    </button>
                                                 </div>
+                                            )}
+                                            {s0.on && !s1.on && (
+                                                <button
+                                                    type="button"
+                                                    class="sched-add-btn"
+                                                    onClick={() => updateSlot(i, 1, { on: true, hour: 15, minute: 0 })}
+                                                    aria-label={`Add ${DAY_NAMES[i]} second slot`}
+                                                >
+                                                    +
+                                                </button>
                                             )}
                                         </div>
                                     </div>
                                 );
                             })}
                         </div>
+
+                        {/* Save button */}
+                        <button
+                            type="button"
+                            class={`settings-save-btn${saving ? " pending" : ""}`}
+                            onClick={handleSave}
+                            disabled={saving || !isDirty}
+                        >
+                            {saving ? "Saving..." : "Save"}
+                        </button>
                     </>
                 )}
             </div>
+
+            {showDiscardConfirm && (
+                <ConfirmDialog
+                    message="You have unsaved changes. Discard them?"
+                    confirmLabel="Discard"
+                    onConfirm={handleDiscard}
+                    onCancel={() => setShowDiscardConfirm(false)}
+                />
+            )}
         </>
     );
+}
+
+// Check if drafts differ from server state (accounts for toggle changes + text edits)
+function draftsMatchDays(drafts: string[][], days: DayState[], server: DayState[]): boolean {
+    for (let d = 0; d < 7; d++) {
+        for (let s = 0; s < SLOTS_PER_DAY; s++) {
+            const cur = days[d].slots[s];
+            const srv = server[d].slots[s];
+            // Toggle state changed
+            if (cur.on !== srv.on) return false;
+            // For enabled slots, check if draft text resolves to a different time
+            if (cur.on) {
+                const parsed = parseTime(drafts[d][s]);
+                if (!parsed) return false; // unparseable = dirty (will fail validation)
+                if (parsed.hour !== srv.hour || parsed.minute !== srv.minute) return false;
+            }
+        }
+    }
+    return true;
 }

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -21,6 +21,7 @@ import { ConfirmDialog } from "../components/confirm-dialog";
 import { ErrorBannerStack, useErrorStack } from "../components/error-banner";
 import { Icon } from "../components/icon";
 import { useNavigate } from "../components/router";
+import { useDirtyGuard } from "../hooks/use-dirty-guard";
 import { usePolling } from "../hooks/use-polling";
 import type { FirmwareVersion, SystemData, UserSettingsData } from "../types";
 import {
@@ -168,13 +169,11 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
     }, [ntfyTopic]);
 
     // --- Dialogs ---
-    const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
     const [showRestartConfirm, setShowRestartConfirm] = useState(false);
     const [showFormatConfirm, setShowFormatConfirm] = useState(false);
     const [showResetConfirm, setShowResetConfirm] = useState(false);
     const [showUploadConfirm, setShowUploadConfirm] = useState(false);
     const [restarting, setRestarting] = useState(false);
-    const pendingNav = useRef<string | null>(null);
 
     // --- Robot power control ---
     const [showRobotRestartConfirm, setShowRobotRestartConfirm] = useState(false);
@@ -235,36 +234,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
 
     // --- Unsaved changes guards ---
 
-    const dirtyRef = useRef(false);
-    dirtyRef.current = isDirty;
-
-    useEffect(() => {
-        const handler = (e: BeforeUnloadEvent) => {
-            if (dirtyRef.current) e.preventDefault();
-        };
-        window.addEventListener("beforeunload", handler);
-        return () => window.removeEventListener("beforeunload", handler);
-    }, []);
-
-    const guardedNavigate = useCallback(
-        (to: string) => {
-            if (isDirty) {
-                pendingNav.current = to;
-                setShowDiscardConfirm(true);
-            } else {
-                navigate(to);
-            }
-        },
-        [isDirty, navigate],
-    );
-
-    const handleDiscard = useCallback(() => {
-        setShowDiscardConfirm(false);
-        if (pendingNav.current) {
-            navigate(pendingNav.current);
-            pendingNav.current = null;
-        }
-    }, [navigate]);
+    const { guardedNavigate, showDiscardConfirm, setShowDiscardConfirm, handleDiscard } = useDirtyGuard(isDirty);
 
     // --- Restart / Factory Reset ---
 

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -97,7 +97,7 @@ export const SIDE_BRUSH_PRESETS: SideBrushPreset[] = [
     { label: "1500 mW (recommended)", value: 1500 },
 ];
 
-export const DEFAULT_SERVER: SettingsData = {
+export const DEFAULT_SERVER = {
     tz: "UTC0",
     logLevel: 0,
     wifiTxPower: 60,


### PR DESCRIPTION
## Summary
- Support two cleaning slots per day (e.g. morning + afternoon on weekdays)
- Show configured timezone on the schedule page
- Batch all schedule changes into a single NVS write via Save button
- Extract dirty navigation guard into shared hook
- Time input with auto-colon formatting and validation at save

Closes #30