### PR TITLE
Add custom ntfy server and auth token support

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -137,6 +137,8 @@ enum CommandStatus {
 
 // NVS keys — Notifications
 #define NVS_KEY_NTFY_TOPIC "ntfy_topic"
+#define NVS_KEY_NTFY_SERVER "ntfy_server"
+#define NVS_KEY_NTFY_TOKEN "ntfy_token"
 #define NVS_KEY_NTFY_ENABLED "ntfy_enabled"
 #define NVS_KEY_NTFY_ON_DONE "ntfy_on_done"
 #define NVS_KEY_NTFY_ON_ERR "ntfy_on_err"

--- a/firmware/src/notification_manager.cpp
+++ b/firmware/src/notification_manager.cpp
@@ -4,9 +4,9 @@
 #include "data_logger.h"
 #include <WiFi.h>
 #include <WiFiClient.h>
+#include <WiFiClientSecure.h>
 
-#define NTFY_HOST "ntfy.sh"
-#define NTFY_PORT 80
+#define NTFY_DEFAULT_HOST "ntfy.sh"
 #define NTFY_CONNECT_TIMEOUT_MS 3000
 
 NotificationManager::NotificationManager(NeatoSerial& neato, SettingsManager& settings, DataLogger& logger) :
@@ -116,28 +116,49 @@ bool NotificationManager::isActiveState(const String& uiState) {
 void NotificationManager::sendNotification(const String& topic, const String& tags, const String& message) {
     LOG("NOTIF", "Sending: [%s] %s", tags.c_str(), message.c_str());
 
-    WiFiClient client;
-    client.setTimeout(NTFY_CONNECT_TIMEOUT_MS);
+    const Settings& cfg = settings.get();
+    String host = cfg.ntfyServer.isEmpty() ? NTFY_DEFAULT_HOST : cfg.ntfyServer;
+    bool useHttps = !cfg.ntfyServer.isEmpty(); // Custom servers use HTTPS; ntfy.sh uses plain HTTP
 
-    if (!client.connect(NTFY_HOST, NTFY_PORT)) {
-        LOG("NOTIF", "Connect to %s:%d failed", NTFY_HOST, NTFY_PORT);
-        dataLogger.logNotification("notif_send_fail", message, false);
-        return;
+    WiFiClientSecure secureClient;
+    WiFiClient plainClient;
+    Client* client;
+
+    if (useHttps) {
+        secureClient.setInsecure(); // Skip cert validation — self-hosted server
+        secureClient.setTimeout(NTFY_CONNECT_TIMEOUT_MS);
+        if (!secureClient.connect(host.c_str(), 443)) {
+            LOG("NOTIF", "TLS connect to %s:443 failed", host.c_str());
+            dataLogger.logNotification("notif_send_fail", message, false);
+            return;
+        }
+        client = &secureClient;
+    } else {
+        plainClient.setTimeout(NTFY_CONNECT_TIMEOUT_MS);
+        if (!plainClient.connect(host.c_str(), 80)) {
+            LOG("NOTIF", "Connect to %s:80 failed", host.c_str());
+            dataLogger.logNotification("notif_send_fail", message, false);
+            return;
+        }
+        client = &plainClient;
     }
 
-    // Build minimal HTTP/1.1 POST request
-    client.print("POST /" + topic + " HTTP/1.1\r\n");
-    client.print("Host: " NTFY_HOST "\r\n");
-    client.print("Content-Type: text/plain\r\n");
-    client.print("Tags: " + tags + "\r\n");
-    client.print("Content-Length: " + String(message.length()) + "\r\n");
-    client.print("Connection: close\r\n");
-    client.print("\r\n");
-    client.print(message);
+    // Build HTTP POST request
+    client->print("POST /" + topic + " HTTP/1.1\r\n");
+    client->print("Host: " + host + "\r\n");
+    client->print("Content-Type: text/plain\r\n");
+    client->print("Tags: " + tags + "\r\n");
+    client->print("Content-Length: " + String(message.length()) + "\r\n");
+    if (!cfg.ntfyToken.isEmpty()) {
+        client->print("Authorization: Bearer " + cfg.ntfyToken + "\r\n");
+    }
+    client->print("Connection: close\r\n");
+    client->print("\r\n");
+    client->print(message);
 
     // Read just the HTTP status line (e.g. "HTTP/1.1 200 OK\r\n")
     bool ok = false;
-    String statusLine = client.readStringUntil('\n');
+    String statusLine = client->readStringUntil('\n');
     if (statusLine.length() > 0) {
         int spaceIdx = statusLine.indexOf(' ');
         if (spaceIdx > 0) {
@@ -147,7 +168,7 @@ void NotificationManager::sendNotification(const String& topic, const String& ta
         }
     }
 
-    client.stop();
+    client->stop();
 
     dataLogger.logNotification("notif_sent", message, ok);
 }

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -58,6 +58,8 @@ void SettingsManager::load() {
     current.vacuumSpeed = prefs.getInt(NVS_KEY_MC_VACUUM_PCT, MANUAL_VACUUM_SPEED_PCT);
     current.sideBrushPower = prefs.getInt(NVS_KEY_MC_SBRUSH_MW, MANUAL_SIDE_BRUSH_POWER_MW);
     current.ntfyTopic = prefs.getString(NVS_KEY_NTFY_TOPIC, "");
+    current.ntfyServer = prefs.getString(NVS_KEY_NTFY_SERVER, "");
+    current.ntfyToken = prefs.getString(NVS_KEY_NTFY_TOKEN, "");
     current.ntfyEnabled = prefs.getBool(NVS_KEY_NTFY_ENABLED, false);
     current.ntfyOnDone = prefs.getBool(NVS_KEY_NTFY_ON_DONE, true);
     current.ntfyOnError = prefs.getBool(NVS_KEY_NTFY_ON_ERR, true);
@@ -83,6 +85,8 @@ void SettingsManager::save() {
     prefs.putInt(NVS_KEY_MC_VACUUM_PCT, current.vacuumSpeed);
     prefs.putInt(NVS_KEY_MC_SBRUSH_MW, current.sideBrushPower);
     prefs.putString(NVS_KEY_NTFY_TOPIC, current.ntfyTopic);
+    prefs.putString(NVS_KEY_NTFY_SERVER, current.ntfyServer);
+    prefs.putString(NVS_KEY_NTFY_TOKEN, current.ntfyToken);
     prefs.putBool(NVS_KEY_NTFY_ENABLED, current.ntfyEnabled);
     prefs.putBool(NVS_KEY_NTFY_ON_DONE, current.ntfyOnDone);
     prefs.putBool(NVS_KEY_NTFY_ON_ERR, current.ntfyOnError);
@@ -226,6 +230,16 @@ ApplyResult SettingsManager::apply(const String& json) {
         changed = true;
         LOG("SETTINGS", "ntfy topic -> %s", current.ntfyTopic.isEmpty() ? "(disabled)" : current.ntfyTopic.c_str());
     }
+    if (incoming.ntfyServer != current.ntfyServer) {
+        current.ntfyServer = incoming.ntfyServer;
+        changed = true;
+        LOG("SETTINGS", "ntfy server -> %s", current.ntfyServer.isEmpty() ? "(ntfy.sh)" : current.ntfyServer.c_str());
+    }
+    if (incoming.ntfyToken != current.ntfyToken) {
+        current.ntfyToken = incoming.ntfyToken;
+        changed = true;
+        LOG("SETTINGS", "ntfy token -> %s", current.ntfyToken.isEmpty() ? "(none)" : "****");
+    }
 
     if (incoming.ntfyEnabled != current.ntfyEnabled) {
         current.ntfyEnabled = incoming.ntfyEnabled;
@@ -300,6 +314,8 @@ std::vector<Field> Settings::toFields() const {
             {"vacuumSpeed", String(vacuumSpeed), FIELD_INT},
             {"sideBrushPower", String(sideBrushPower), FIELD_INT},
             {"ntfyTopic", ntfyTopic, FIELD_STRING},
+            {"ntfyServer", ntfyServer, FIELD_STRING},
+            {"ntfyToken", ntfyToken, FIELD_STRING},
             {"ntfyEnabled", ntfyEnabled ? "true" : "false", FIELD_BOOL},
             {"ntfyOnDone", ntfyOnDone ? "true" : "false", FIELD_BOOL},
             {"ntfyOnError", ntfyOnError ? "true" : "false", FIELD_BOOL},
@@ -362,6 +378,14 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
     }
     if ((f = findField(fields, "ntfyTopic")) && f->type == FIELD_STRING) {
         ntfyTopic = f->value;
+        applied = true;
+    }
+    if ((f = findField(fields, "ntfyServer")) && f->type == FIELD_STRING) {
+        ntfyServer = f->value;
+        applied = true;
+    }
+    if ((f = findField(fields, "ntfyToken")) && f->type == FIELD_STRING) {
+        ntfyToken = f->value;
         applied = true;
     }
     if ((f = findField(fields, "ntfyEnabled")) && f->type == FIELD_BOOL) {

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -28,8 +28,10 @@ struct Settings : public JsonSerializable {
     int vacuumSpeed = MANUAL_VACUUM_SPEED_PCT; // Vacuum speed % (40-100)
     int sideBrushPower = MANUAL_SIDE_BRUSH_POWER_MW; // Side brush power in mW (500-1500)
 
-    // Notifications (ntfy.sh)
+    // Notifications (ntfy)
     String ntfyTopic; // Empty = disabled
+    String ntfyServer; // Custom server hostname (empty = ntfy.sh)
+    String ntfyToken; // Access token for authenticated servers (empty = no auth)
     bool ntfyEnabled = false; // Global switch — must be on for any notification to fire
     bool ntfyOnDone = true; // Notify when cleaning completes
     bool ntfyOnError = true; // Notify on robot error (UI_ERROR_*, code 243+)

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -250,6 +250,8 @@ const state = {
     vacuumSpeed: 80,
     sideBrushPower: 1500,
     ntfyTopic: "",
+    ntfyServer: "",
+    ntfyToken: "",
     ntfyEnabled: true,
     ntfyOnDone: true,
     ntfyOnError: true,
@@ -709,6 +711,8 @@ const routes = {
             "vacuumSpeed",
             "sideBrushPower",
             "ntfyTopic",
+            "ntfyServer",
+            "ntfyToken",
             "ntfyEnabled",
             "ntfyOnDone",
             "ntfyOnError",
@@ -1019,6 +1023,8 @@ const handleRequest = async (req, res) => {
             if (data.vacuumSpeed !== undefined) state.vacuumSpeed = data.vacuumSpeed;
             if (data.sideBrushPower !== undefined) state.sideBrushPower = data.sideBrushPower;
             if (data.ntfyTopic !== undefined) state.ntfyTopic = data.ntfyTopic;
+            if (data.ntfyServer !== undefined) state.ntfyServer = data.ntfyServer;
+            if (data.ntfyToken !== undefined) state.ntfyToken = data.ntfyToken;
             if (data.ntfyEnabled !== undefined) state.ntfyEnabled = data.ntfyEnabled;
             if (data.ntfyOnDone !== undefined) state.ntfyOnDone = data.ntfyOnDone;
             if (data.ntfyOnError !== undefined) state.ntfyOnError = data.ntfyOnError;
@@ -1050,6 +1056,8 @@ const handleRequest = async (req, res) => {
                 "vacuumSpeed",
                 "sideBrushPower",
                 "ntfyTopic",
+                "ntfyServer",
+                "ntfyToken",
                 "ntfyEnabled",
                 "ntfyOnDone",
                 "ntfyOnError",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -53,7 +53,9 @@ export interface SettingsData {
     brushRpm: number; // Main brush RPM (500-1600)
     vacuumSpeed: number; // Vacuum speed % (40-100)
     sideBrushPower: number; // Side brush power in mW (500-1500)
-    ntfyTopic: string; // ntfy.sh topic for push notifications (empty = disabled)
+    ntfyTopic: string; // ntfy topic for push notifications (empty = disabled)
+    ntfyServer: string; // Custom ntfy server hostname (empty = ntfy.sh)
+    ntfyToken: string; // Access token for authenticated ntfy servers (empty = no auth)
     ntfyEnabled: boolean; // Global switch — must be on for any notification to fire
     ntfyOnDone: boolean; // Notify when cleaning completes
     ntfyOnError: boolean; // Notify on robot error (UI_ERROR_*, code 243+)

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -95,6 +95,10 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         setSideBrushPower,
         ntfyTopic,
         setNtfyTopic,
+        ntfyServer,
+        setNtfyServer,
+        ntfyToken,
+        setNtfyToken,
         ntfyEnabled,
         setNtfyEnabled,
         ntfyOnDone,
@@ -510,7 +514,9 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                         <div class="settings-toggle-row">
                             <div class="settings-toggle-label">
                                 <span class="settings-toggle-title">Enable notifications</span>
-                                <span class="settings-toggle-desc">Push alerts via ntfy.sh over plain HTTP</span>
+                                <span class="settings-toggle-desc">
+                                    Push alerts via ntfy (custom server or ntfy.sh)
+                                </span>
                             </div>
                             <button
                                 type="button"
@@ -540,6 +546,22 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                                         {testingNotif ? "..." : (notifTestResult ?? "Test")}
                                     </button>
                                 </div>
+                                <input
+                                    type="text"
+                                    class="settings-text-input"
+                                    value={ntfyServer}
+                                    onInput={(e) => setNtfyServer((e.target as HTMLInputElement).value)}
+                                    disabled={saving}
+                                    placeholder="Server hostname (blank = ntfy.sh)"
+                                />
+                                <input
+                                    type="password"
+                                    class="settings-text-input"
+                                    value={ntfyToken}
+                                    onInput={(e) => setNtfyToken((e.target as HTMLInputElement).value)}
+                                    disabled={saving}
+                                    placeholder="Access token (blank = no auth)"
+                                />
                                 <div class="settings-toggle-row">
                                     <div class="settings-toggle-label">
                                         <span class="settings-toggle-title">Cleaning done</span>

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -110,6 +110,8 @@ export const DEFAULT_SERVER: SettingsData = {
     vacuumSpeed: 80,
     sideBrushPower: 1500,
     ntfyTopic: "",
+    ntfyServer: "",
+    ntfyToken: "",
     ntfyEnabled: false,
     ntfyOnDone: true,
     ntfyOnError: true,

--- a/frontend/src/views/settings/use-settings-form.ts
+++ b/frontend/src/views/settings/use-settings-form.ts
@@ -19,6 +19,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     const [vacuumSpeed, setVacuumSpeed] = useState(80);
     const [sideBrushPower, setSideBrushPower] = useState(1500);
     const [ntfyTopic, setNtfyTopic] = useState("");
+    const [ntfyServer, setNtfyServer] = useState("");
+    const [ntfyToken, setNtfyToken] = useState("");
     const [ntfyEnabled, setNtfyEnabled] = useState(false);
     const [ntfyOnDone, setNtfyOnDone] = useState(true);
     const [ntfyOnError, setNtfyOnError] = useState(true);
@@ -51,6 +53,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
             setVacuumSpeed(fetched.vacuumSpeed);
             setSideBrushPower(fetched.sideBrushPower);
             setNtfyTopic(fetched.ntfyTopic ?? "");
+            setNtfyServer(fetched.ntfyServer ?? "");
+            setNtfyToken(fetched.ntfyToken ?? "");
             setNtfyEnabled(fetched.ntfyEnabled ?? false);
             setNtfyOnDone(fetched.ntfyOnDone ?? true);
             setNtfyOnError(fetched.ntfyOnError ?? true);
@@ -75,6 +79,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
             vacuumSpeed !== server.current.vacuumSpeed ||
             sideBrushPower !== server.current.sideBrushPower ||
             ntfyTopic !== (server.current.ntfyTopic ?? "") ||
+            ntfyServer !== (server.current.ntfyServer ?? "") ||
+            ntfyToken !== (server.current.ntfyToken ?? "") ||
             ntfyEnabled !== (server.current.ntfyEnabled ?? false) ||
             ntfyOnDone !== (server.current.ntfyOnDone ?? true) ||
             ntfyOnError !== (server.current.ntfyOnError ?? true) ||
@@ -119,6 +125,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         if (vacuumSpeed !== server.current.vacuumSpeed) patch.vacuumSpeed = vacuumSpeed;
         if (sideBrushPower !== server.current.sideBrushPower) patch.sideBrushPower = sideBrushPower;
         if (ntfyTopic !== (server.current.ntfyTopic ?? "")) patch.ntfyTopic = ntfyTopic;
+        if (ntfyServer !== (server.current.ntfyServer ?? "")) patch.ntfyServer = ntfyServer;
+        if (ntfyToken !== (server.current.ntfyToken ?? "")) patch.ntfyToken = ntfyToken;
         if (ntfyEnabled !== (server.current.ntfyEnabled ?? false)) patch.ntfyEnabled = ntfyEnabled;
         if (ntfyOnDone !== (server.current.ntfyOnDone ?? true)) patch.ntfyOnDone = ntfyOnDone;
         if (ntfyOnError !== (server.current.ntfyOnError ?? true)) patch.ntfyOnError = ntfyOnError;
@@ -137,6 +145,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         vacuumSpeed,
         sideBrushPower,
         ntfyTopic,
+        ntfyServer,
+        ntfyToken,
         ntfyEnabled,
         ntfyOnDone,
         ntfyOnError,
@@ -202,6 +212,10 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         setSideBrushPower,
         ntfyTopic,
         setNtfyTopic,
+        ntfyServer,
+        setNtfyServer,
+        ntfyToken,
+        setNtfyToken,
         ntfyEnabled,
         setNtfyEnabled,
         ntfyOnDone,


### PR DESCRIPTION
Replace the hardcoded ntfy.sh server with configurable ntfyServer and ntfyToken settings. Custom servers connect via HTTPS with Bearer token auth; the default ntfy.sh fallback still uses plain HTTP. Adds server hostname and access token inputs to the web UI notifications section.