### PR TITLE
Show device hostname on dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,11 +55,11 @@ pio run -e c3-debug                        # Build
 pio run -e c3-debug -t upload              # Upload via USB
 pio run -e c3-debug -t upload -t monitor   # Upload + serial monitor
 pio run -e c3-release                      # Release build (no serial logging)
-python scripts/check_format.py             # clang-format check (--fix to auto-fix)
+./scripts/check_format.py                  # clang-format check (--fix to auto-fix)
 pio check -e c3-debug                      # Static analysis (clang-tidy)
 ```
 
-Verify firmware changes: `pio run -e c3-debug` + `python scripts/check_format.py` +
+Verify firmware changes: `pio run -e c3-debug` + `./scripts/check_format.py` +
 `pio check -e c3-debug` with zero defects.
 
 Verify frontend changes: `npm run check` + `npm run build` in `frontend/`.

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -322,6 +322,7 @@ void WebServer::registerFirmwareRoutes() {
                 {"version", fwMgr.getFirmwareVersion(), FIELD_STRING},
                 {"chip", fwMgr.getChipModel(), FIELD_STRING},
                 {"model", neato.getModelName(), FIELD_STRING},
+                {"hostname", settingsMgr.get().hostname, FIELD_STRING},
                 {"supported", isSupportedModel(neato.getModelName()) ? "true" : "false", FIELD_BOOL},
                 {"identifying", neato.isIdentifying() ? "true" : "false", FIELD_BOOL},
         };

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -781,6 +781,7 @@ const routes = {
         jsonResponse(res, {
             version: state.firmwareVersion ?? getVersion(),
             chip: "ESP32-C3",
+            hostname: "neato-kitchen",
             supported: !state.unsupported && !state.identifying,
             identifying: state.identifying,
         });

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -141,6 +141,12 @@ body {
     color: var(--text);
 }
 
+.header-hostname {
+    font-size: 0.8em;
+    font-weight: 400;
+    opacity: 0.55;
+}
+
 /* Status bar */
 
 .status-bar {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -113,6 +113,7 @@ export interface LidarScan {
 export interface FirmwareVersion {
     version: string;
     chip: string;
+    hostname: string;
     supported: boolean;
     identifying: boolean;
 }

--- a/frontend/src/views/dashboard.tsx
+++ b/frontend/src/views/dashboard.tsx
@@ -204,7 +204,10 @@ export function DashboardView({ firmware, state, isManual, updateInfo, robotRead
         <>
             {/* Header */}
             <div class="header">
-                <h1>OpenNeato</h1>
+                <h1>
+                    OpenNeato
+                    {firmware.data?.hostname && <span class="header-hostname"> ({firmware.data.hostname})</span>}
+                </h1>
                 <div class="header-btns">
                     <button
                         type="button"


### PR DESCRIPTION
## Summary
- Add hostname to the firmware/version API response
- Display it next to the OpenNeato title in the dashboard header
- Users with multiple robots can now tell which device they are looking at

Closes #49