### PR TITLE
Fix displayed robot time ignoring DST offset

### DIFF
--- a/firmware/src/system_manager.cpp
+++ b/firmware/src/system_manager.cpp
@@ -147,6 +147,8 @@ std::vector<Field> SystemHealth::toFields() const {
             {"time", String(static_cast<long>(time)), FIELD_INT},
             {"timeSource", timeSource, FIELD_STRING},
             {"tz", tz, FIELD_STRING},
+            {"localTime", localTime, FIELD_STRING},
+            {"isDst", isDst ? "true" : "false", FIELD_BOOL},
     };
 }
 
@@ -162,5 +164,19 @@ SystemHealth SystemManager::getSystemHealth(const String& tz) const {
     h.time = now();
     h.timeSource = ntpSynced ? "ntp" : (fallbackSet ? "fallback" : "millis");
     h.tz = tz;
+
+    // Compute DST-aware local time string via localtime_r (same conversion the
+    // scheduler uses). The POSIX TZ string applied via configTzTime() handles
+    // DST transitions, so this is always correct for the configured timezone.
+    if (h.time > 1700000000) {
+        struct tm tm;
+        localtime_r(&h.time, &tm);
+        static const char *DAYS[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+        char buf[20];
+        snprintf(buf, sizeof(buf), "%s %02d:%02d:%02d", DAYS[tm.tm_wday], tm.tm_hour, tm.tm_min, tm.tm_sec);
+        h.localTime = buf;
+        h.isDst = tm.tm_isdst > 0;
+    }
+
     return h;
 }

--- a/firmware/src/system_manager.h
+++ b/firmware/src/system_manager.h
@@ -21,6 +21,8 @@ struct SystemHealth : public JsonSerializable {
     time_t time = 0;
     String timeSource;
     String tz;
+    String localTime; // DST-aware local time string, e.g. "Sat 17:45:01"
+    bool isDst = false; // true when daylight saving time is active
 
     std::vector<Field> toFields() const override;
 };

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -682,6 +682,10 @@ const routes = {
 
     // System routes
     "GET /api/system": (_req, res) => {
+        const now = new Date();
+        const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+        const pad = (n) => n.toString().padStart(2, "0");
+        const localTime = `${days[now.getDay()]} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
         jsonResponse(res, {
             heap: rand(160000, 200000),
             heapTotal: 327680,
@@ -693,6 +697,8 @@ const routes = {
             time: Math.floor(Date.now() / 1000),
             timeSource: "ntp",
             tz: state.tz,
+            localTime,
+            isDst: now.getTimezoneOffset() !== new Date(now.getFullYear(), 0, 1).getTimezoneOffset(),
         });
     },
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,6 +38,8 @@ export interface SystemData {
     time: number;
     timeSource: string;
     tz: string;
+    localTime: string; // DST-aware local time, e.g. "Sat 17:45:01"
+    isDst: boolean; // true when daylight saving time is active
 }
 
 // Per-day schedule fields (Mon=0..Sun=6), two slots per day.

--- a/frontend/src/views/schedule.tsx
+++ b/frontend/src/views/schedule.tsx
@@ -7,8 +7,8 @@ import { ErrorBannerStack, useErrorStack } from "../components/error-banner";
 import { Icon } from "../components/icon";
 import { useDirtyGuard } from "../hooks/use-dirty-guard";
 import { useFetch } from "../hooks/use-fetch";
-import type { SettingsData } from "../types";
-import { findPresetLabel } from "./settings/helpers";
+import type { SettingsData, SystemData } from "../types";
+import { findCurrentTzAbbrev, findPresetLabel } from "./settings/helpers";
 
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const SLOTS_PER_DAY = 2;
@@ -74,7 +74,18 @@ function parseTime(value: string): { hour: number; minute: number } | null {
     return { hour: Number.parseInt(match[1], 10), minute: Number.parseInt(match[2], 10) };
 }
 
-function tzLabel(tz: string): string {
+function tzLabel(tz: string, isDst?: boolean): string {
+    // Show abbreviation with current offset, e.g. "EEST (UTC+3)"
+    if (isDst !== undefined) {
+        const abbrev = findCurrentTzAbbrev(tz, isDst);
+        const preset = findPresetLabel(tz);
+        if (abbrev && preset) {
+            const offset = preset.replace(/^.*\(UTC([^)]+)\/([^)]+)\).*$/, (_m, std, dst) => (isDst ? dst : std));
+            // If regex matched (DST zone), show "EEST (UTC+3)"; otherwise just use the preset label
+            return offset !== preset ? `${abbrev} (UTC${offset})` : preset;
+        }
+        if (abbrev) return abbrev;
+    }
     const preset = findPresetLabel(tz);
     if (preset) return preset;
     const match = tz.match(/^([A-Z]{2,5})/);
@@ -111,6 +122,7 @@ export function ScheduleView() {
     const [saving, setSaving] = useState(false);
 
     const { data: settings, loading, error: fetchError } = useFetch(api.getSettings);
+    const { data: system } = useFetch<SystemData>(api.getSystem);
 
     const [enabled, setEnabled] = useState(false);
     const [tz, setTz] = useState("UTC0");
@@ -265,7 +277,7 @@ export function ScheduleView() {
                             />
                         </div>
 
-                        <div class="schedule-tz-hint">Times are in {tzLabel(tz)}</div>
+                        <div class="schedule-tz-hint">Times are in {tzLabel(tz, system?.isDst)}</div>
 
                         {/* Day rows */}
                         <div class="schedule-days">

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -32,7 +32,7 @@ import {
     TX_POWER_PRESETS,
     VACUUM_PRESETS,
 } from "./settings/constants";
-import { findPresetLabel, formatRobotTime } from "./settings/helpers";
+import { findPresetLabel } from "./settings/helpers";
 import { SettingsCategory } from "./settings/settings-category";
 import { useFirmwareUpload } from "./settings/use-firmware-upload";
 import { useReboot } from "./settings/use-reboot";
@@ -415,10 +415,10 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                                 )}
                             </select>
                         </div>
-                        {system?.time && (
+                        {system?.localTime && (
                             <div class="settings-robot-time">
                                 <Icon svg={clockSvg} />
-                                Robot time: {formatRobotTime(system.time, tz)}
+                                Robot time: {system.localTime}
                             </div>
                         )}
                     </div>

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -3,6 +3,8 @@ import type { SettingsData } from "../../types";
 interface TimezonePreset {
     label: string;
     tz: string;
+    std?: string; // Standard time abbreviation, e.g. "EET"
+    dst?: string; // DST abbreviation, e.g. "EEST"
 }
 
 interface TxPowerPreset {
@@ -11,24 +13,24 @@ interface TxPowerPreset {
 }
 
 // Common timezone presets — label shown in UI, value is POSIX TZ string
-// UTC offset shown is the standard (non-DST) offset
+// Zones with DST show both offsets (standard/summer) to avoid confusion
 export const TIMEZONE_PRESETS: TimezonePreset[] = [
     { label: "UTC (UTC+0)", tz: "UTC0" },
-    { label: "US Hawaii (UTC-10)", tz: "HST10" },
-    { label: "US Alaska (UTC-9)", tz: "AKST9AKDT,M3.2.0,M11.1.0" },
-    { label: "US Pacific (UTC-8)", tz: "PST8PDT,M3.2.0,M11.1.0" },
-    { label: "US Mountain (UTC-7)", tz: "MST7MDT,M3.2.0,M11.1.0" },
-    { label: "US Central (UTC-6)", tz: "CST6CDT,M3.2.0,M11.1.0" },
-    { label: "US Eastern (UTC-5)", tz: "EST5EDT,M3.2.0,M11.1.0" },
-    { label: "UK / Ireland (UTC+0)", tz: "GMT0BST,M3.5.0/1,M10.5.0" },
-    { label: "Central Europe (UTC+1)", tz: "CET-1CEST,M3.5.0,M10.5.0/3" },
-    { label: "Eastern Europe (UTC+2)", tz: "EET-2EEST,M3.5.0/3,M10.5.0/4" },
-    { label: "Turkey (UTC+3)", tz: "<+03>-3" },
-    { label: "India (UTC+5:30)", tz: "IST-5:30" },
-    { label: "China / Singapore (UTC+8)", tz: "CST-8" },
-    { label: "Japan / Korea (UTC+9)", tz: "JST-9" },
-    { label: "Australia Eastern (UTC+10)", tz: "AEST-10AEDT,M10.1.0,M4.1.0/3" },
-    { label: "New Zealand (UTC+12)", tz: "NZST-12NZDT,M9.5.0,M4.1.0/3" },
+    { label: "US Hawaii (UTC-10)", tz: "HST10", std: "HST" },
+    { label: "US Alaska (UTC-9/-8)", tz: "AKST9AKDT,M3.2.0,M11.1.0", std: "AKST", dst: "AKDT" },
+    { label: "US Pacific (UTC-8/-7)", tz: "PST8PDT,M3.2.0,M11.1.0", std: "PST", dst: "PDT" },
+    { label: "US Mountain (UTC-7/-6)", tz: "MST7MDT,M3.2.0,M11.1.0", std: "MST", dst: "MDT" },
+    { label: "US Central (UTC-6/-5)", tz: "CST6CDT,M3.2.0,M11.1.0", std: "CST", dst: "CDT" },
+    { label: "US Eastern (UTC-5/-4)", tz: "EST5EDT,M3.2.0,M11.1.0", std: "EST", dst: "EDT" },
+    { label: "UK / Ireland (UTC+0/+1)", tz: "GMT0BST,M3.5.0/1,M10.5.0", std: "GMT", dst: "BST" },
+    { label: "Central Europe (UTC+1/+2)", tz: "CET-1CEST,M3.5.0,M10.5.0/3", std: "CET", dst: "CEST" },
+    { label: "Eastern Europe (UTC+2/+3)", tz: "EET-2EEST,M3.5.0/3,M10.5.0/4", std: "EET", dst: "EEST" },
+    { label: "Turkey (UTC+3)", tz: "<+03>-3", std: "TRT" },
+    { label: "India (UTC+5:30)", tz: "IST-5:30", std: "IST" },
+    { label: "China / Singapore (UTC+8)", tz: "CST-8", std: "CST" },
+    { label: "Japan / Korea (UTC+9)", tz: "JST-9", std: "JST" },
+    { label: "Australia Eastern (UTC+10/+11)", tz: "AEST-10AEDT,M10.1.0,M4.1.0/3", std: "AEST", dst: "AEDT" },
+    { label: "New Zealand (UTC+12/+13)", tz: "NZST-12NZDT,M9.5.0,M4.1.0/3", std: "NZST", dst: "NZDT" },
 ];
 
 // WiFi TX power presets — value is in 0.25 dBm units (ESP32 wifi_power_t)

--- a/frontend/src/views/settings/helpers.ts
+++ b/frontend/src/views/settings/helpers.ts
@@ -5,26 +5,9 @@ export function findPresetLabel(tz: string): string | null {
     return match ? match.label : null;
 }
 
-export function formatRobotTime(epochSec: number, tz: string): string {
-    try {
-        const date = new Date(epochSec * 1000);
-        // POSIX format: STDoffset[DST[offset][,rule]] — offset is hours WEST of UTC
-        const offsetMatch = tz.match(/[A-Z]+(-?\d+)(?::(\d+))?/);
-        if (offsetMatch) {
-            const hours = parseInt(offsetMatch[1], 10);
-            const mins = offsetMatch[2] ? parseInt(offsetMatch[2], 10) : 0;
-            const offsetMs = -(hours * 60 + (hours < 0 ? -mins : mins)) * 60 * 1000;
-            const local = new Date(date.getTime() + offsetMs);
-            const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-            const day = days[local.getUTCDay()];
-            const h = local.getUTCHours().toString().padStart(2, "0");
-            const m = local.getUTCMinutes().toString().padStart(2, "0");
-            const s = local.getUTCSeconds().toString().padStart(2, "0");
-            return `${day} ${h}:${m}:${s}`;
-        }
-    } catch {
-        // fall through
-    }
-    const d = new Date(epochSec * 1000);
-    return d.toUTCString().replace(" GMT", " UTC");
+// Return the current timezone abbreviation (e.g. "EEST" during DST, "EET" otherwise).
+export function findCurrentTzAbbrev(tz: string, isDst: boolean): string | null {
+    const match = TIMEZONE_PRESETS.find((p) => p.tz === tz);
+    if (!match) return null;
+    return isDst && match.dst ? match.dst : (match.std ?? null);
 }


### PR DESCRIPTION
## Summary
- Return DST-aware `localTime` and `isDst` from firmware `/api/system` via `localtime_r`
- Remove broken client-side POSIX TZ offset parsing (`formatRobotTime`)
- Show both standard and DST offsets in timezone dropdown labels (e.g. "UTC+2/+3")
- Show current timezone abbreviation on schedule page (e.g. "EEST (UTC+3)" in summer)
- Add `std`/`dst` abbreviation fields to timezone presets

Fixes #60