### PR TITLE
Show local time on dashboard and schedule page

### DIFF
--- a/frontend/src/views/dashboard.tsx
+++ b/frontend/src/views/dashboard.tsx
@@ -84,19 +84,6 @@ function battColor(pct: number): string {
     return "green";
 }
 
-function formatUptime(ms: number): string {
-    const s = Math.floor(ms / 1000);
-    if (s < 60) return `${s}s`;
-    const m = Math.floor(s / 60);
-    if (m < 60) return `${m}m`;
-    const h = Math.floor(m / 60);
-    const rm = m % 60;
-    if (h < 24) return rm ? `${h}h ${rm}m` : `${h}h`;
-    const d = Math.floor(h / 24);
-    const rh = h % 24;
-    return rh ? `${d}d ${rh}h` : `${d}d`;
-}
-
 function wifiStrength(rssi: number): string {
     if (rssi >= -50) return "Excellent";
     if (rssi >= -60) return "Good";
@@ -240,10 +227,10 @@ export function DashboardView({ firmware, state, isManual, updateInfo, robotRead
                         </div>
                     </div>
                     <div class="status-bar-item">
-                        <div class="status-bar-label">Uptime</div>
+                        <div class="status-bar-label">Time</div>
                         <div class="status-bar-value">
                             <Icon svg={clockSvg} />
-                            {formatUptime(system.data.uptime)}
+                            {system.data.localTime}
                         </div>
                     </div>
                     <div class="status-bar-item">

--- a/frontend/src/views/schedule.tsx
+++ b/frontend/src/views/schedule.tsx
@@ -75,18 +75,18 @@ function parseTime(value: string): { hour: number; minute: number } | null {
 }
 
 function tzLabel(tz: string, isDst?: boolean): string {
-    // Show abbreviation with current offset, e.g. "EEST (UTC+3)"
-    if (isDst !== undefined) {
-        const abbrev = findCurrentTzAbbrev(tz, isDst);
-        const preset = findPresetLabel(tz);
-        if (abbrev && preset) {
-            const offset = preset.replace(/^.*\(UTC([^)]+)\/([^)]+)\).*$/, (_m, std, dst) => (isDst ? dst : std));
-            // If regex matched (DST zone), show "EEST (UTC+3)"; otherwise just use the preset label
-            return offset !== preset ? `${abbrev} (UTC${offset})` : preset;
-        }
-        if (abbrev) return abbrev;
-    }
+    const abbrev = isDst !== undefined ? findCurrentTzAbbrev(tz, isDst) : null;
     const preset = findPresetLabel(tz);
+    if (abbrev && preset) {
+        // Extract the active UTC offset from the preset label
+        const dstMatch = preset.match(/\(UTC([^)]+)\/([^)]+)\)/);
+        const offset = dstMatch ? `UTC${isDst ? dstMatch[2] : dstMatch[1]}` : null;
+        if (!offset) {
+            const stdMatch = preset.match(/\(UTC([^)]+)\)/);
+            return stdMatch ? `UTC${stdMatch[1]}` : abbrev;
+        }
+        return `${abbrev}, ${offset}`;
+    }
     if (preset) return preset;
     const match = tz.match(/^([A-Z]{2,5})/);
     return match ? match[1] : tz;
@@ -277,7 +277,11 @@ export function ScheduleView() {
                             />
                         </div>
 
-                        <div class="schedule-tz-hint">Times are in {tzLabel(tz, system?.isDst)}</div>
+                        <div class="schedule-tz-hint">
+                            {system?.localTime
+                                ? `${system.localTime} - ${tzLabel(tz, system.isDst)}`
+                                : `Times are in ${tzLabel(tz)}`}
+                        </div>
 
                         {/* Day rows */}
                         <div class="schedule-days">

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -5,7 +5,6 @@ import backSvg from "../assets/icons/back.svg?raw";
 import bellSvg from "../assets/icons/bell.svg?raw";
 import calendarSvg from "../assets/icons/calendar.svg?raw";
 import chipSvg from "../assets/icons/chip.svg?raw";
-import clockSvg from "../assets/icons/clock.svg?raw";
 import databaseSvg from "../assets/icons/database.svg?raw";
 import gearSvg from "../assets/icons/gear.svg?raw";
 import manualSvg from "../assets/icons/manual.svg?raw";
@@ -415,12 +414,6 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                                 )}
                             </select>
                         </div>
-                        {system?.localTime && (
-                            <div class="settings-robot-time">
-                                <Icon svg={clockSvg} />
-                                Robot time: {system.localTime}
-                            </div>
-                        )}
                     </div>
                     <div class="settings-section">
                         <div class="settings-section-title">UART Pins</div>

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -3,7 +3,7 @@ import type { SettingsData } from "../../types";
 interface TimezonePreset {
     label: string;
     tz: string;
-    std?: string; // Standard time abbreviation, e.g. "EET"
+    std: string; // Standard time abbreviation, e.g. "EET"
     dst?: string; // DST abbreviation, e.g. "EEST"
 }
 
@@ -15,7 +15,7 @@ interface TxPowerPreset {
 // Common timezone presets — label shown in UI, value is POSIX TZ string
 // Zones with DST show both offsets (standard/summer) to avoid confusion
 export const TIMEZONE_PRESETS: TimezonePreset[] = [
-    { label: "UTC (UTC+0)", tz: "UTC0" },
+    { label: "UTC (UTC+0)", tz: "UTC0", std: "UTC" },
     { label: "US Hawaii (UTC-10)", tz: "HST10", std: "HST" },
     { label: "US Alaska (UTC-9/-8)", tz: "AKST9AKDT,M3.2.0,M11.1.0", std: "AKST", dst: "AKDT" },
     { label: "US Pacific (UTC-8/-7)", tz: "PST8PDT,M3.2.0,M11.1.0", std: "PST", dst: "PDT" },

--- a/frontend/src/views/settings/helpers.ts
+++ b/frontend/src/views/settings/helpers.ts
@@ -9,5 +9,5 @@ export function findPresetLabel(tz: string): string | null {
 export function findCurrentTzAbbrev(tz: string, isDst: boolean): string | null {
     const match = TIMEZONE_PRESETS.find((p) => p.tz === tz);
     if (!match) return null;
-    return isDst && match.dst ? match.dst : (match.std ?? null);
+    return isDst && match.dst ? match.dst : match.std;
 }


### PR DESCRIPTION
## Summary
- Replace uptime with DST-aware local time in the dashboard status bar
- Show current time with timezone abbreviation on the schedule page (e.g. "Sat 21:03:34 - EEST, UTC+3")
- Remove robot time display from settings (moved to dashboard)
- Make `std` required on timezone presets, add `std` to UTC

Closes #59