### PR TITLE
Fix SetTime ignored on D7 4.6.0, use GetVersion for fallback clock

### DIFF
--- a/docs/neato-serial-protocol.md
+++ b/docs/neato-serial-protocol.md
@@ -122,6 +122,11 @@ Robot GND -> ESP GND. The robot provides 3.3V to power the ESP.
   - Hour: 0-23 (required)
   - Min: 0-59 (required)
   - Sec: 0-59 (optional, defaults to 0)
+  - All: YYYY-MM-DD--hh:mm:ss (optional, sets full date/time on RTC instead of scheduler clock)
+  - **D7 4.6.0 quirk:** The Day/Hour/Min/Sec parameters have no effect - the scheduler clock
+    (`GetTime`) is stuck at `Sunday 0:00:00` and cannot be written. Use `SetTime All` instead,
+    which updates the real RTC visible via `GetVersion` `Time Local`/`Time UTC` fields.
+- `SetNTPTime` — Instruct the robot to sync its clock from NTP servers (D7 only, requires robot WiFi)
 - `SetWallFollower [Enable|Disable]` — Enable/disable wall follower
 - `TestMode On/Off` — Enable/disable test mode
 - `DiagTest [TestsOff|DrivePath|DriveForever|MoveAndBump|DropTest|...]` — Execute test modes
@@ -406,6 +411,12 @@ Locale,1,LOCALE_USA, LDS Software,V1.0.0,, LDS Serial,XXX-YYY,, LDS CPU,F2802x/c
 MainBoard Vendor ID,1,, MainBoard Serial Number,99,, MainBoard Version,15,0,
 ChassisRev,-1,, UIPanelRev,-1,,
 ```
+D7 (and possibly D6) also include time fields:
+```
+Time Local,Sat Apr 11 22:26:13 2026
+Time UTC,Sat Apr 11 19:26:13 2026
+```
+These reflect the robot's real RTC and are the reliable source for robot clock readback.
 
 **GetWarranty** — Three hex values, convert with `strtoul(hex, nullptr, 16)`
 
@@ -692,6 +703,8 @@ Wed 00:00 R Thu 00:00 R Fri 00:00 H Sat 00:00 H
 (R = spot clean, H = house clean, None = no cleaning)
 
 **GetTime** — Returns: `DayOfWeek HourOf24:Min:Sec` Example: `Sunday 13:57:09`
+**D7 4.6.0 quirk:** Always returns `Sunday 0:00:00` regardless of `SetTime`. Use `GetVersion`
+`Time UTC` field for reliable robot clock readback instead.
 
 **GetLifeStatLog** — Returns multiple LifeStat logs from oldest to newest, non-zero entries only:
 Format: `runID,statID,count,Min,Max,Sum,SumV*2`

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -188,7 +188,6 @@ enum CommandStatus {
 #define NTP_SERVER_1 "pool.ntp.org"
 #define NTP_SERVER_2 "time.nist.gov"
 #define NTP_DEFAULT_TZ "UTC0" // POSIX TZ string, stored in NVS
-#define ROBOT_TIME_SYNC_INTERVAL_MS 14400000 // Push NTP to robot every 4 hours
 
 // Logging — enabled by default, disable with -DENABLE_LOGGING=0
 #ifndef ENABLE_LOGGING

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -32,25 +32,8 @@ CleaningHistory cleaningHistory(neatoSerial, dataLogger, systemManager);
 WebServer webServer(server, neatoSerial, dataLogger, systemManager, firmwareManager, settingsManager, manualClean,
                     notifMgr, cleaningHistory);
 
-// Robot time sync state (managed here, not in SystemManager)
-unsigned long lastRobotSync = 0;
-
 // Tracks whether web server has been started (may be deferred if WiFi was slow at boot)
 bool webServerStarted = false;
-
-
-// Push NTP time to robot clock via SetTime
-static void syncRobotClock() {
-    time_t t = time(nullptr);
-    if (t <= 1700000000)
-        return;
-
-    struct tm tm;
-    localtime_r(&t, &tm);
-
-    neatoSerial.setTime(tm.tm_wday, tm.tm_hour, tm.tm_min, tm.tm_sec,
-                        [](bool ok) { LOG("MAIN", "Robot clock sync %s", ok ? "OK" : "FAILED"); });
-}
 
 void setup() {
     Serial.begin(115200);
@@ -123,12 +106,10 @@ void setup() {
     systemManager.begin();
     systemManager.applyTimezone(settingsManager.get().tz);
 
-    // Wire NTP sync callback: push time to robot, log the event
+    // Wire NTP sync callback: log the event
     systemManager.onNtpSync([&] {
         time_t t = time(nullptr);
         dataLogger.logNtp("sync_ok", {{"epoch", String(static_cast<long>(t)), FIELD_INT}});
-        syncRobotClock();
-        lastRobotSync = millis();
     });
 
     // Initialize web server and OTA if WiFi is already connected.
@@ -154,22 +135,14 @@ void setup() {
     dataLogger.setLogLevelCheck([&]() { return settingsManager.get().logLevel; });
     dataLogger.begin();
 
-    // Fetch robot time as fallback clock
-    neatoSerial.getTime([](bool ok, const TimeData& t) {
-        if (!ok) {
-            LOG("MAIN", "GetTime failed, no robot clock available");
+    // Fetch robot time as fallback clock (parsed from "Time UTC" in GetVersion)
+    neatoSerial.getVersion([](bool ok, const VersionData& v) {
+        if (!ok || v.timeUtc == 0) {
+            LOG("MAIN", "GetVersion time not available, no robot clock fallback");
             return;
         }
-        struct tm tm = {};
-        tm.tm_year = 2025 - 1900;
-        tm.tm_mon = 0;
-        tm.tm_mday = 1;
-        tm.tm_hour = t.hour;
-        tm.tm_min = t.minute;
-        tm.tm_sec = t.second;
-        time_t epoch = mktime(&tm);
-        systemManager.setFallbackClock(epoch);
-        LOG("MAIN", "Robot time: %02d:%02d:%02d -> epoch %ld", t.hour, t.minute, t.second, static_cast<long>(epoch));
+        systemManager.setFallbackClock(v.timeUtc);
+        LOG("MAIN", "Robot clock fallback set from GetVersion: epoch %ld", static_cast<long>(v.timeUtc));
     });
 
     // Start task watchdog AFTER all slow init is complete (SPIFFS mount,
@@ -258,10 +231,4 @@ void loop() {
     // each constructor): NeatoSerial, ManualCleanManager, SystemManager, DataLogger,
     // NotificationManager, Scheduler. Each respects its own LoopTask interval.
     TaskRegistry::tickAll();
-
-    // Periodic robot time re-sync from NTP (every 4 hours)
-    if (systemManager.isNtpSynced() && millis() - lastRobotSync >= ROBOT_TIME_SYNC_INTERVAL_MS) {
-        syncRobotClock();
-        lastRobotSync = millis();
-    }
 }

--- a/firmware/src/neato_commands.cpp
+++ b/firmware/src/neato_commands.cpp
@@ -260,15 +260,6 @@ std::vector<Field> ErrorData::toFields() const {
     };
 }
 
-std::vector<Field> TimeData::toFields() const {
-    return {
-            {"dayOfWeek", String(dayOfWeek), FIELD_INT},
-            {"hour", String(hour), FIELD_INT},
-            {"minute", String(minute), FIELD_INT},
-            {"second", String(second), FIELD_INT},
-    };
-}
-
 // -- LDS scan special serializers --------------------------------------------
 
 String LdsScanData::toJson() const {
@@ -332,6 +323,39 @@ bool parseVersionData(const String& raw, VersionData& out) {
     if (findCsvValue(raw, "MainBoard Version", val)) {
         out.mainBoardVersion = val;
         out.mainBoardVersion.replace(",", ".");
+    }
+    // Parse "Time UTC" field, format: "Sat Apr 11 19:26:13 2026"
+    if (findCsvValue(raw, "Time UTC", val)) {
+        val.trim();
+        struct tm tm = {};
+        // Skip day-of-week prefix (e.g. "Sat ")
+        int space = val.indexOf(' ');
+        if (space > 0) {
+            String rest = val.substring(space + 1);
+            static const char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+            // Parse "Apr 11 19:26:13 2026"
+            String monStr = rest.substring(0, 3);
+            int mon = -1;
+            for (int i = 0; i < 12; i++) {
+                if (monStr.equalsIgnoreCase(months[i])) {
+                    mon = i;
+                    break;
+                }
+            }
+            int day = 0, hour = 0, min = 0, sec = 0, year = 0;
+            if (mon >= 0 && sscanf(rest.c_str() + 4, "%d %d:%d:%d %d", &day, &hour, &min, &sec, &year) == 5 &&
+                year >= 2020) {
+                // Compute UTC epoch directly (avoids mktime which applies local TZ)
+                static const int cumDays[] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
+                int y = year - 1;
+                long days = 365L * (year - 1970) + (y / 4 - y / 100 + y / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400);
+                days += cumDays[mon] + day - 1;
+                if (mon > 1 && (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)))
+                    days++; // leap year adjustment
+                out.timeUtc = static_cast<time_t>(days) * 86400 + hour * 3600 + min * 60 + sec;
+            }
+        }
     }
     return out.modelName.length() > 0 || out.softwareVersion.length() > 0;
 }
@@ -580,38 +604,6 @@ bool parseLdsScanData(const String& raw, LdsScanData& out) {
     return foundData;
 }
 
-// -- Time parser -------------------------------------------------------------
-
-bool parseTimeData(const String& raw, TimeData& out) {
-    // Format: "Sunday 13:57:09" (DayOfWeek HH:MM:SS)
-    String line = raw;
-    line.trim();
-
-    // Map day name to number
-    static const char *days[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
-    int spaceIdx = line.indexOf(' ');
-    if (spaceIdx < 0)
-        return false;
-
-    String dayName = line.substring(0, spaceIdx);
-    out.dayOfWeek = -1;
-    for (int i = 0; i < 7; i++) {
-        if (dayName.equalsIgnoreCase(days[i])) {
-            out.dayOfWeek = i;
-            break;
-        }
-    }
-
-    String timeStr = line.substring(spaceIdx + 1);
-    int h = 0, m = 0, s = 0;
-    if (sscanf(timeStr.c_str(), "%d:%d:%d", &h, &m, &s) != 3)
-        return false;
-
-    out.hour = h;
-    out.minute = m;
-    out.second = s;
-    return true;
-}
 
 // -- User settings -----------------------------------------------------------
 

--- a/firmware/src/neato_commands.h
+++ b/firmware/src/neato_commands.h
@@ -16,7 +16,6 @@
 #define CMD_GET_ERR_CLEAR "GetErr Clear"
 #define CMD_GET_LDS_SCAN "GetLDSScan"
 
-#define CMD_GET_TIME "GetTime"
 #define CMD_GET_CAL_INFO "GetCalInfo"
 #define CMD_GET_LIFE_STAT_LOG "GetLifeStatLog"
 #define CMD_GET_WARRANTY "GetWarranty"
@@ -29,8 +28,6 @@
 #define CMD_SET_LDS_ROTATION_ON "SetLDSRotation On"
 #define CMD_SET_LDS_ROTATION_OFF "SetLDSRotation Off"
 #define CMD_PLAY_SOUND "PlaySound"
-#define CMD_SET_TIME "SetTime"
-
 // -- SetEvent constants (D3-D7, requires SKey) --------------------------------
 #define CMD_SET_EVENT_PREFIX "SetEvent event "
 #define CMD_SET_EVENT_SKEY " SKey "
@@ -83,6 +80,7 @@ struct VersionData : public JsonSerializable {
     String ldsVersion;
     String ldsSerial;
     String mainBoardVersion;
+    time_t timeUtc = 0; // Parsed from "Time UTC" field (0 = not available)
 
     std::vector<Field> toFields() const override;
 };
@@ -157,16 +155,7 @@ struct ErrorData : public JsonSerializable {
     std::vector<Field> toFields() const override;
 };
 
-struct TimeData : public JsonSerializable {
-    int dayOfWeek = -1; // 0=Sunday .. 6=Saturday
-    int hour = 0;
-    int minute = 0;
-    int second = 0;
-
-    std::vector<Field> toFields() const override;
-};
-
-// LDS scan — special case, does not use toFields()
+// LDS scan - special case, does not use toFields()
 struct LdsScanPoint {
     int angleDeg = 0;
     int distMM = 0;
@@ -223,7 +212,6 @@ bool parseMotorData(const String& raw, MotorData& out);
 bool parseRobotState(const String& raw, RobotState& out);
 bool parseErrorData(const String& raw, ErrorData& out);
 bool parseLdsScanData(const String& raw, LdsScanData& out);
-bool parseTimeData(const String& raw, TimeData& out);
 bool parseRobotPosData(const String& raw, RobotPosData& out);
 bool parseUserSettingsData(const String& raw, UserSettingsData& out);
 

--- a/firmware/src/neato_serial.cpp
+++ b/firmware/src/neato_serial.cpp
@@ -671,23 +671,6 @@ bool NeatoSerial::powerControl(const String& action, std::function<void(bool)> c
     });
 }
 
-// -- Time commands -----------------------------------------------------------
-
-bool NeatoSerial::getTime(std::function<void(bool, const TimeData&)> callback) {
-    return enqueue(CMD_GET_TIME, [callback](bool ok, const String& raw) {
-        TimeData data;
-        if (ok)
-            ok = parseTimeData(raw, data);
-        callback(ok, data);
-    });
-}
-
-bool NeatoSerial::setTime(int dayOfWeek, int hour, int min, int sec, std::function<void(bool)> callback) {
-    String cmd = String(CMD_SET_TIME) + " Day " + String(dayOfWeek) + " Hour " + String(hour) + " Min " + String(min) +
-                 " Sec " + String(sec);
-    return enqueue(cmd, wrapAction(callback));
-}
-
 bool NeatoSerial::sendRaw(const String& cmd, std::function<void(bool, const String&)> callback) {
     if (cmd.isEmpty())
         return false;

--- a/firmware/src/neato_serial.h
+++ b/firmware/src/neato_serial.h
@@ -69,7 +69,7 @@ public:
     bool setMotorBrush(int rpm, std::function<void(bool)> callback = nullptr);
     bool setMotorVacuum(bool on, int speedPercent = 80, std::function<void(bool)> callback = nullptr);
     bool setMotorSideBrush(bool on, int powerMw = 5000, std::function<void(bool)> callback = nullptr);
-    bool setTime(int dayOfWeek, int hour, int min, int sec, std::function<void(bool)> callback = nullptr);
+
 
     // Set a single robot user setting via "SetUserSettings <key> <value>".
     // Invalidates the user settings cache.
@@ -81,10 +81,6 @@ public:
 
     // -- Raw command (temporary debug endpoint) --------------------------------
     bool sendRaw(const String& cmd, std::function<void(bool, const String&)> callback);
-
-    // -- Time query --------------------------------------------------------------
-
-    bool getTime(std::function<void(bool, const TimeData&)> callback);
 
     // -- Cache invalidation --------------------------------------------------
     // Call after actions that change robot state (cleaning, test mode, etc.)


### PR DESCRIPTION
## Summary

- Remove `syncRobotClock`, `setTime`, `getTime`, `TimeData` and periodic 4h sync - robot manages its own clock via onboard WiFi + NTP
- Parse `Time UTC` from `GetVersion` response as fallback clock when ESP32 NTP is unavailable
- Document `SetTime All` parameter, `SetNTPTime` command, and D7 4.6.0 quirks in protocol docs

Fixes #63