### PR TITLE
Add manual error clearing button in diagnostics settings

### DIFF
--- a/firmware/src/neato_commands.h
+++ b/firmware/src/neato_commands.h
@@ -40,6 +40,7 @@
 #define CMD_SET_MOTOR "SetMotor"
 #define CMD_SET_SYSTEM_MODE_POWER_CYCLE "SetSystemMode PowerCycle"
 #define CMD_SET_SYSTEM_MODE_SHUTDOWN "SetSystemMode Shutdown"
+#define CMD_SET_UI_ERROR_CLEAR_ALL "SetUIError clearall"
 #define CMD_GET_ROBOT_POS_RAW "GetRobotPos Raw"
 #define CMD_GET_ROBOT_POS_SMOOTH "GetRobotPos Smooth"
 #define CMD_GET_USER_SETTINGS "GetUserSettings"

--- a/firmware/src/neato_serial.cpp
+++ b/firmware/src/neato_serial.cpp
@@ -671,6 +671,13 @@ bool NeatoSerial::powerControl(const String& action, std::function<void(bool)> c
     });
 }
 
+// -- Clear errors ------------------------------------------------------------
+
+bool NeatoSerial::clearErrors(std::function<void(bool)> callback) {
+    invalidateState();
+    return enqueue(CMD_SET_UI_ERROR_CLEAR_ALL, wrapAction(callback));
+}
+
 bool NeatoSerial::sendRaw(const String& cmd, std::function<void(bool, const String&)> callback) {
     if (cmd.isEmpty())
         return false;

--- a/firmware/src/neato_serial.h
+++ b/firmware/src/neato_serial.h
@@ -79,6 +79,9 @@ public:
     // action = "restart" (PowerCycle) or "shutdown" (Shutdown).
     bool powerControl(const String& action, std::function<void(bool)> callback = nullptr);
 
+    // Clear all UI errors/warnings via "SetUIError clearall".
+    bool clearErrors(std::function<void(bool)> callback = nullptr);
+
     // -- Raw command (temporary debug endpoint) --------------------------------
     bool sendRaw(const String& cmd, std::function<void(bool, const String&)> callback);
 

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -99,6 +99,7 @@ void WebServer::registerApiRoutes() {
     registerPostRoute("/api/power", neato, &NeatoSerial::powerControl, {"action"});
     registerPostRoute("/api/lidar/rotate", neato, &NeatoSerial::setLdsRotation, {"enable"});
     registerPostRoute("/api/user-settings", neato, &NeatoSerial::setUserSetting, {"key", "value"});
+    registerPostRoute("/api/clear-errors", neato, &NeatoSerial::clearErrors, {});
 
     // Serial endpoint — send arbitrary serial command, returns raw response.
     // Always available (no debug gate — useful for diagnostics without enabling verbose logging).

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -625,6 +625,11 @@ const routes = {
         }
     },
 
+    "POST /api/clear-errors": (_req, res) => {
+        if (faults.actions) return sendError(res, "UART timeout: robot not responding", 500);
+        sendOk(res);
+    },
+
     "POST /api/sound": (_req, res) => {
         // Accept and ignore — just acknowledge
         sendOk(res);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -142,11 +142,12 @@ export const api = {
         post(`/api/manual/motors?brush=${brush ? 1 : 0}&vacuum=${vacuum ? 1 : 0}&sideBrush=${sideBrush ? 1 : 0}`),
     getManualStatus: () => get<ManualStatus>("/api/manual/status"),
     getLidar: () => get<LidarScan>("/api/lidar"),
-    lidarRotate: (enable: boolean) => post(`/api/lidar/rotate?enable=${enable ? 1 : 0}`),
+
     getSettings: () => get<SettingsData>("/api/settings"),
     updateSettings: (patch: Partial<SettingsData>) => put<SettingsData>("/api/settings", patch),
     testNotification: (topic: string) => post(`/api/notifications/test?topic=${encodeURIComponent(topic)}`),
-    playSound: (id: number) => post(`/api/sound?id=${id}`),
+
+    clearErrors: () => post("/api/clear-errors"),
     robotRestart: () => post("/api/power?action=restart"),
     robotShutdown: () => post("/api/power?action=shutdown"),
     restart: () => post("/api/system/restart"),
@@ -164,7 +165,7 @@ export const api = {
     uploadFirmware: (file: File, md5: string, onProgress: (pct: number) => void) =>
         uploadFirmware(file, md5, onProgress),
     saveSchedule: (patch: Partial<SettingsData>) => put<SettingsData>("/api/settings", patch),
-    setScheduleEnabled: (on: boolean) => put<SettingsData>("/api/settings", { scheduleEnabled: on }),
+
     getUserSettings: () => get<UserSettingsData>("/api/user-settings"),
     setUserSetting: (key: string, value: string) =>
         post(`/api/user-settings?key=${encodeURIComponent(key)}&value=${encodeURIComponent(value)}`),

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -232,6 +232,20 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         navigate("/");
     }, [navigate]);
 
+    // --- Clear errors ---
+    const [showClearErrorsConfirm, setShowClearErrorsConfirm] = useState(false);
+    const [clearingErrors, setClearingErrors] = useState(false);
+
+    const handleClearErrors = useCallback(() => {
+        setShowClearErrorsConfirm(false);
+        setClearingErrors(true);
+        api.clearErrors()
+            .catch((e: unknown) => {
+                errorStack.push(e instanceof Error ? e.message : "Failed to clear errors");
+            })
+            .finally(() => setClearingErrors(false));
+    }, [errorStack]);
+
     // --- Unsaved changes guards ---
 
     const { guardedNavigate, showDiscardConfirm, setShowDiscardConfirm, handleDiscard } = useDirtyGuard(isDirty);
@@ -790,6 +804,19 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                             <span class="settings-nav-chevron">&rsaquo;</span>
                         </button>
                     </div>
+                    <div class="settings-section">
+                        <button
+                            type="button"
+                            class="settings-nav-row"
+                            onClick={() => setShowClearErrorsConfirm(true)}
+                            disabled={clearingErrors || firmware?.supported === false}
+                        >
+                            <div class="settings-nav-row-left">
+                                <Icon svg={alertSvg} />
+                                Clear Robot Errors
+                            </div>
+                        </button>
+                    </div>
                 </SettingsCategory>
 
                 <button
@@ -1025,6 +1052,15 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                         fw.startUpload();
                     }}
                     onCancel={() => setShowUploadConfirm(false)}
+                />
+            )}
+
+            {showClearErrorsConfirm && (
+                <ConfirmDialog
+                    message="Clear all robot errors and warnings? This dismisses any active error state on the robot."
+                    confirmLabel="Clear"
+                    onConfirm={handleClearErrors}
+                    onCancel={() => setShowClearErrorsConfirm(false)}
                 />
             )}
 


### PR DESCRIPTION
- Add `POST /api/clear-errors` endpoint that sends `SetUIError clearall` to the robot
- Add "Clear Robot Errors" button in Settings > Diagnostics with confirmation dialog
- Remove unused frontend API methods (`lidarRotate`, `playSound`, `setScheduleEnabled`)

Closes #66