### PR TITLE
feat: zoom and pan gestures on cleaning map

### DIFF
--- a/frontend/src/hooks/use-map-gestures.ts
+++ b/frontend/src/hooks/use-map-gestures.ts
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import type { MapTransform } from "../types";
+
+const DEFAULT_TRANSFORM: MapTransform = { panX: 0, panY: 0, zoom: 1 };
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 5;
+const WHEEL_ZOOM_SPEED = 0.002;
+const DOUBLE_TAP_MS = 300;
+const DOUBLE_TAP_ZOOM = 2.5;
+
+// Manages pan, zoom, and reset gestures for a canvas element.
+// Returns the current transform and a reset function.
+export function useMapGestures(canvasRef: { current: HTMLCanvasElement | null }): MapTransform {
+    const [transform, setTransform] = useState<MapTransform>(DEFAULT_TRANSFORM);
+
+    // Mutable refs for gesture state to avoid re-attaching listeners
+    const tRef = useRef<MapTransform>(DEFAULT_TRANSFORM);
+    const dragging = useRef(false);
+    const dragStart = useRef({ x: 0, y: 0 });
+    const panStart = useRef({ x: 0, y: 0 });
+    const lastTapTime = useRef(0);
+    const pinching = useRef(false);
+    const pinchStartDist = useRef(0);
+    const pinchStartZoom = useRef(1);
+    const pinchMidStart = useRef({ x: 0, y: 0 });
+    const pinchPanStart = useRef({ x: 0, y: 0 });
+
+    const commit = useCallback((next: MapTransform) => {
+        tRef.current = next;
+        setTransform(next);
+    }, []);
+
+    const reset = useCallback(() => {
+        commit(DEFAULT_TRANSFORM);
+    }, [commit]);
+
+    // Clamp pan so the zoomed content always covers the viewport.
+    // At zoom Z on a canvas of size W, the zoomed content spans [panX, panX + W*Z].
+    // We require it to cover [0, W]: panX <= 0 and panX >= W - W*Z = -W*(Z-1).
+    const clampPan = useCallback(
+        (panX: number, panY: number, zoom: number): { panX: number; panY: number } => {
+            const canvas = canvasRef.current;
+            if (!canvas) return { panX, panY };
+            const w = canvas.clientWidth;
+            const h = canvas.clientHeight;
+            const minPanX = -w * (zoom - 1);
+            const minPanY = -h * (zoom - 1);
+            return {
+                panX: Math.max(minPanX, Math.min(0, panX)),
+                panY: Math.max(minPanY, Math.min(0, panY)),
+            };
+        },
+        [canvasRef],
+    );
+
+    // Zoom around a point in canvas-local coordinates
+    const zoomAt = useCallback(
+        (localX: number, localY: number, newZoom: number) => {
+            const prev = tRef.current;
+            const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+            const ratio = clamped / prev.zoom;
+            const nextPanX = localX - ratio * (localX - prev.panX);
+            const nextPanY = localY - ratio * (localY - prev.panY);
+            const pan = clampPan(nextPanX, nextPanY, clamped);
+            commit({ panX: pan.panX, panY: pan.panY, zoom: clamped });
+        },
+        [clampPan, commit],
+    );
+
+    // Convert client coordinates to canvas-local coordinates
+    const toLocal = useCallback(
+        (clientX: number, clientY: number): { x: number; y: number } => {
+            const canvas = canvasRef.current;
+            if (!canvas) return { x: clientX, y: clientY };
+            const rect = canvas.getBoundingClientRect();
+            return { x: clientX - rect.left, y: clientY - rect.top };
+        },
+        [canvasRef],
+    );
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        // --- Wheel zoom ---
+        const onWheel = (e: WheelEvent) => {
+            e.preventDefault();
+            const delta = -e.deltaY * WHEEL_ZOOM_SPEED;
+            const local = toLocal(e.clientX, e.clientY);
+            zoomAt(local.x, local.y, tRef.current.zoom * (1 + delta));
+        };
+
+        // --- Pointer (mouse only) drag ---
+        const onPointerDown = (e: PointerEvent) => {
+            if (e.button !== 0) return;
+            if (e.pointerType === "touch") return;
+            dragging.current = true;
+            dragStart.current = { x: e.clientX, y: e.clientY };
+            panStart.current = { x: tRef.current.panX, y: tRef.current.panY };
+            canvas.setPointerCapture(e.pointerId);
+        };
+
+        const onPointerMove = (e: PointerEvent) => {
+            if (!dragging.current) return;
+            const dx = e.clientX - dragStart.current.x;
+            const dy = e.clientY - dragStart.current.y;
+            const pan = clampPan(panStart.current.x + dx, panStart.current.y + dy, tRef.current.zoom);
+            commit({ ...tRef.current, panX: pan.panX, panY: pan.panY });
+        };
+
+        const onPointerUp = () => {
+            dragging.current = false;
+        };
+
+        // --- Double-click: zoom in when at 1x, reset otherwise ---
+        const onDoubleClick = (e: MouseEvent) => {
+            e.preventDefault();
+            if (tRef.current.zoom <= MIN_ZOOM) {
+                const local = toLocal(e.clientX, e.clientY);
+                zoomAt(local.x, local.y, DOUBLE_TAP_ZOOM);
+            } else {
+                reset();
+            }
+        };
+
+        // --- Touch gestures ---
+        const onTouchStart = (e: TouchEvent) => {
+            // Prevent Safari's built-in double-tap-to-zoom on all
+            // touches within the canvas.
+            e.preventDefault();
+
+            if (e.touches.length === 2) {
+                // Entering pinch - cancel any single-finger drag
+                dragging.current = false;
+                pinching.current = true;
+                const [a, b] = [e.touches[0], e.touches[1]];
+                pinchStartDist.current = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+                pinchStartZoom.current = tRef.current.zoom;
+                pinchMidStart.current = {
+                    x: (a.clientX + b.clientX) / 2,
+                    y: (a.clientY + b.clientY) / 2,
+                };
+                pinchPanStart.current = { x: tRef.current.panX, y: tRef.current.panY };
+            } else if (e.touches.length === 1 && !pinching.current) {
+                // Single-finger drag (only if not exiting a pinch)
+                dragging.current = true;
+                dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+                panStart.current = { x: tRef.current.panX, y: tRef.current.panY };
+
+                // Double-tap: zoom in when at 1x, reset otherwise
+                const now = Date.now();
+                if (now - lastTapTime.current < DOUBLE_TAP_MS) {
+                    if (tRef.current.zoom <= MIN_ZOOM) {
+                        const local = toLocal(e.touches[0].clientX, e.touches[0].clientY);
+                        zoomAt(local.x, local.y, DOUBLE_TAP_ZOOM);
+                    } else {
+                        reset();
+                    }
+                    dragging.current = false;
+                    lastTapTime.current = 0;
+                } else {
+                    lastTapTime.current = now;
+                }
+            }
+        };
+
+        const onTouchMove = (e: TouchEvent) => {
+            e.preventDefault();
+            if (e.touches.length === 2 && pinching.current) {
+                const [a, b] = [e.touches[0], e.touches[1]];
+                const dist = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+                const newZoom = Math.max(
+                    MIN_ZOOM,
+                    Math.min(MAX_ZOOM, pinchStartZoom.current * (dist / pinchStartDist.current)),
+                );
+
+                // Midpoint in canvas-local coords for zoom anchor
+                const midX = (a.clientX + b.clientX) / 2;
+                const midY = (a.clientY + b.clientY) / 2;
+                const midLocal = toLocal(midX, midY);
+                const midStartLocal = toLocal(pinchMidStart.current.x, pinchMidStart.current.y);
+
+                // Zoom around the initial pinch midpoint, then apply
+                // the two-finger pan delta on top.
+                const ratio = newZoom / pinchStartZoom.current;
+                const nextPanX = midStartLocal.x - ratio * (midStartLocal.x - pinchPanStart.current.x);
+                const nextPanY = midStartLocal.y - ratio * (midStartLocal.y - pinchPanStart.current.y);
+                // Add the movement of the midpoint as a pan offset
+                const panDx = midLocal.x - midStartLocal.x;
+                const panDy = midLocal.y - midStartLocal.y;
+                const pan = clampPan(nextPanX + panDx, nextPanY + panDy, newZoom);
+                commit({ panX: pan.panX, panY: pan.panY, zoom: newZoom });
+            } else if (e.touches.length === 1 && dragging.current) {
+                const dx = e.touches[0].clientX - dragStart.current.x;
+                const dy = e.touches[0].clientY - dragStart.current.y;
+                const pan = clampPan(panStart.current.x + dx, panStart.current.y + dy, tRef.current.zoom);
+                commit({ ...tRef.current, panX: pan.panX, panY: pan.panY });
+            }
+        };
+
+        const onTouchEnd = (e: TouchEvent) => {
+            if (e.touches.length < 2 && pinching.current) {
+                // Pinch ended - snapshot state so a remaining finger can
+                // continue as a single-finger pan without a jump.
+                pinching.current = false;
+                if (e.touches.length === 1) {
+                    dragging.current = true;
+                    dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+                    panStart.current = { x: tRef.current.panX, y: tRef.current.panY };
+                }
+            }
+            if (e.touches.length === 0) {
+                dragging.current = false;
+                pinching.current = false;
+            }
+        };
+
+        canvas.addEventListener("wheel", onWheel, { passive: false });
+        canvas.addEventListener("pointerdown", onPointerDown);
+        canvas.addEventListener("pointermove", onPointerMove);
+        canvas.addEventListener("pointerup", onPointerUp);
+        canvas.addEventListener("pointercancel", onPointerUp);
+        canvas.addEventListener("dblclick", onDoubleClick);
+        canvas.addEventListener("touchstart", onTouchStart, { passive: false });
+        canvas.addEventListener("touchmove", onTouchMove, { passive: false });
+        canvas.addEventListener("touchend", onTouchEnd);
+
+        return () => {
+            canvas.removeEventListener("wheel", onWheel);
+            canvas.removeEventListener("pointerdown", onPointerDown);
+            canvas.removeEventListener("pointermove", onPointerMove);
+            canvas.removeEventListener("pointerup", onPointerUp);
+            canvas.removeEventListener("pointercancel", onPointerUp);
+            canvas.removeEventListener("dblclick", onDoubleClick);
+            canvas.removeEventListener("touchstart", onTouchStart);
+            canvas.removeEventListener("touchmove", onTouchMove);
+            canvas.removeEventListener("touchend", onTouchEnd);
+        };
+    }, [canvasRef, clampPan, commit, reset, toLocal, zoomAt]);
+
+    // Reset transform when canvas ref changes (new map loaded)
+    useEffect(() => {
+        commit(DEFAULT_TRANSFORM);
+    }, [canvasRef.current, commit]);
+
+    return transform;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2204,6 +2204,7 @@ body {
     border-radius: 12px;
     overflow: hidden;
     background: var(--surface);
+    touch-action: manipulation;
 }
 
 .history-canvas {
@@ -2211,6 +2212,12 @@ body {
     width: 100%;
     aspect-ratio: 1;
     max-height: 70vh;
+    touch-action: none;
+    cursor: grab;
+}
+
+.history-canvas:active {
+    cursor: grabbing;
 }
 
 .history-legend {
@@ -2279,6 +2286,14 @@ body {
 .history-legend-bolt svg {
     width: 14px;
     height: 14px;
+}
+
+.history-map-hint {
+    text-align: center;
+    font-size: 11px;
+    color: var(--text-dim);
+    opacity: 0.6;
+    margin-top: 6px;
 }
 
 /* Schedule page */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -209,6 +209,12 @@ export interface MapRechargePoint {
     y: number;
 }
 
+export interface MapTransform {
+    panX: number;
+    panY: number;
+    zoom: number;
+}
+
 export interface MapData {
     session: MapSession | null;
     summary: MapSummary | null;

--- a/frontend/src/views/history/helpers.ts
+++ b/frontend/src/views/history/helpers.ts
@@ -4,7 +4,9 @@ import clockSvg from "../../assets/icons/clock.svg?raw";
 import houseSvg from "../../assets/icons/house.svg?raw";
 import manualSvg from "../../assets/icons/manual.svg?raw";
 import spotSvg from "../../assets/icons/spot.svg?raw";
-import type { MapData } from "../../types";
+import type { MapData, MapTransform } from "../../types";
+
+const DEFAULT_TRANSFORM: MapTransform = { panX: 0, panY: 0, zoom: 1 };
 
 export function formatDuration(secs: number): string {
     if (secs < 60) return `${secs}s`;
@@ -30,9 +32,11 @@ export function modeInfo(mode: string): { label: string; icon: string } {
 }
 
 // Canvas renderer for map visualization
-export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = false) {
+export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = false, tf?: MapTransform) {
     const ctx = canvas.getContext("2d");
     if (!ctx || !map.bounds) return;
+
+    const { panX, panY, zoom } = tf ?? DEFAULT_TRANSFORM;
 
     const dpr = window.devicePixelRatio || 1;
     const displayW = canvas.clientWidth;
@@ -40,6 +44,11 @@ export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = f
     canvas.width = displayW * dpr;
     canvas.height = displayH * dpr;
     ctx.scale(dpr, dpr);
+
+    // Apply zoom + pan: zoom from top-left origin, panX/panY computed by
+    // useMapGestures already account for the cursor-relative zoom anchor.
+    ctx.translate(panX, panY);
+    ctx.scale(zoom, zoom);
 
     const { minX, maxX, minY, maxY } = map.bounds;
     const worldW = maxX - minX;

--- a/frontend/src/views/history/item.tsx
+++ b/frontend/src/views/history/item.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "preact/hooks";
 import boltSvg from "../../assets/icons/bolt.svg?raw";
 import { Icon } from "../../components/icon";
+import { useMapGestures } from "../../hooks/use-map-gestures";
 import type { HistoryFileInfo, MapData } from "../../types";
 import { formatDuration, renderMap } from "./helpers";
 
@@ -13,23 +14,24 @@ interface HistoryItemViewProps {
 
 export function HistoryItemView({ file, map, mapEmpty, recording }: HistoryItemViewProps) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
+    const transform = useMapGestures(canvasRef);
 
-    // Render canvas when map data changes
+    // Render canvas when map data or transform changes
     useEffect(() => {
         if (map && canvasRef.current) {
-            renderMap(canvasRef.current, map, recording);
+            renderMap(canvasRef.current, map, recording, transform);
         }
-    }, [map, recording]);
+    }, [map, recording, transform]);
 
     // Re-render on resize
     useEffect(() => {
         if (!map) return;
         const handleResize = () => {
-            if (map && canvasRef.current) renderMap(canvasRef.current, map, recording);
+            if (map && canvasRef.current) renderMap(canvasRef.current, map, recording, transform);
         };
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
-    }, [map, recording]);
+    }, [map, recording, transform]);
 
     // Prefer list metadata summary (available immediately), fall back to
     // the summary parsed from the full JSONL data (available after fetch)
@@ -97,6 +99,9 @@ export function HistoryItemView({ file, map, mapEmpty, recording }: HistoryItemV
                         </span>
                     )}
                 </div>
+            )}
+            {map && (
+                <div class="history-map-hint">Pinch or scroll to zoom, drag to pan, double-tap to zoom in or reset</div>
             )}
         </>
     );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig(({ command }) => {
     const isDev = command === "serve";
-    const serverHost = "localhost";
+    const serverHost = "0.0.0.0";
     const serverPort = 5173;
     return {
         plugins: [preact(), ...(isDev ? [require("./mock/server.js").mockApiPlugin()] : [])],


### PR DESCRIPTION
## Summary

- Add `useMapGestures` hook with pinch-to-zoom, scroll wheel zoom, click/touch drag pan, and double-tap to zoom in/reset
- Update `renderMap` to accept a transform parameter for zoom and pan
- Add CSS for touch-action, cursor styles, and controls hint below legend
- Bind dev server to 0.0.0.0 for mobile testing

Closes #75