### PR TITLE
Add navigation mode selection for house cleaning

### DIFF
--- a/docs/neato-serial-protocol.md
+++ b/docs/neato-serial-protocol.md
@@ -270,6 +270,13 @@ Robot GND -> ESP GND. The robot provides 3.3V to power the ESP.
   - `IEC1mTest` — Run IEC cleaning test
   - `MaxModeEnable` — Enable max cleaning mode
   - `MaxModeDisable` — Disable max cleaning mode
+- `SetNavigationMode [Normal|Gentle|Deep|Quick]` — Set navigation mode for house cleaning
+  - `Normal` — Default navigation behavior
+  - `Gentle` — Extra care: robot avoids pushing objects taller than itself (detected via LIDAR)
+  - `Deep` — Robot drives deep into corners, backs up, and cleans corners in a curve
+  - `Quick` — Faster, less thorough navigation
+  - Mode resets to Normal on robot restart (not persisted by robot firmware)
+  - Only affects house cleaning, not spot cleaning
 - `ClearFiles [BB] [All] [Life]` — Clear log files
   - `BB` — Clear managed logs in BlackBox directory
   - `All` — Additionally clear unmanaged files (crash logs, etc.)

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -129,6 +129,8 @@ enum CommandStatus {
 #define NVS_KEY_WIFI_TX_POWER "wifi_tx_pwr"
 #define NVS_KEY_UART_TX_PIN "uart_tx_pin"
 #define NVS_KEY_UART_RX_PIN "uart_rx_pin"
+// NVS keys — Cleaning
+#define NVS_KEY_NAV_MODE "nav_mode" // Navigation mode: "Normal", "Gentle", "Deep", "Quick"
 // NVS keys — Manual clean
 #define NVS_KEY_MC_STALL_THR "mc_stall_thr"
 #define NVS_KEY_MC_BRUSH_RPM "mc_brush_rpm"

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -74,6 +74,9 @@ void setup() {
     // immediately when a clean command is sent via API.
     neatoSerial.onCleanStart([&] { cleaningHistory.notifyCleanStart(); });
 
+    // Wire navigation mode getter so clean() sends SetNavigationMode before house cleans
+    neatoSerial.setNavModeGetter([&] { return settingsManager.get().navMode; });
+
     // Wire WiFi events to data logger BEFORE WiFi connects so boot events are captured.
     // DataLogger buffers entries in memory - they get flushed once SPIFFS mounts in begin().
     WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {

--- a/firmware/src/neato_commands.h
+++ b/firmware/src/neato_commands.h
@@ -45,6 +45,7 @@
 #define CMD_GET_ROBOT_POS_SMOOTH "GetRobotPos Smooth"
 #define CMD_GET_USER_SETTINGS "GetUserSettings"
 #define CMD_SET_USER_SETTINGS "SetUserSettings"
+#define CMD_SET_NAVIGATION_MODE "SetNavigationMode"
 
 // -- Sound IDs ---------------------------------------------------------------
 

--- a/firmware/src/neato_serial.cpp
+++ b/firmware/src/neato_serial.cpp
@@ -531,11 +531,24 @@ bool NeatoSerial::clean(const String& action, std::function<void(bool)> callback
     }
 
     // New clean from idle
-    const char *evt = (action == "spot") ? EVT_START_SPOT : EVT_START_HOUSE;
     invalidateState();
     if (cleanStartCallback)
         cleanStartCallback();
-    return enqueue(buildSetEvent(evt), wrapAction(callback), PRIORITY_HIGH);
+
+    if (action == "spot") {
+        return enqueue(buildSetEvent(EVT_START_SPOT), wrapAction(callback), PRIORITY_HIGH);
+    }
+
+    // House clean — send navigation mode first, then start cleaning.
+    // SetNavigationMode is fire-and-forget; house clean proceeds regardless.
+    if (navModeGetter) {
+        String mode = navModeGetter();
+        if (mode.length() > 0 && mode != "Normal") {
+            String cmd = String(CMD_SET_NAVIGATION_MODE) + " " + mode;
+            enqueue(cmd, nullptr, PRIORITY_HIGH);
+        }
+    }
+    return enqueue(buildSetEvent(EVT_START_HOUSE), wrapAction(callback), PRIORITY_HIGH);
 }
 
 bool NeatoSerial::testMode(bool enable, std::function<void(bool)> callback) {
@@ -638,6 +651,11 @@ bool NeatoSerial::setMotorSideBrush(bool on, int powerMw, std::function<void(boo
 bool NeatoSerial::setUserSetting(const String& key, const String& value, std::function<void(bool)> callback) {
     userSettingsCache.invalidate();
     String cmd = String(CMD_SET_USER_SETTINGS) + " " + key + " " + value;
+    return enqueue(cmd, wrapAction(callback));
+}
+
+bool NeatoSerial::setNavigationMode(const String& mode, std::function<void(bool)> callback) {
+    String cmd = String(CMD_SET_NAVIGATION_MODE) + " " + mode;
     return enqueue(cmd, wrapAction(callback));
 }
 

--- a/firmware/src/neato_serial.h
+++ b/firmware/src/neato_serial.h
@@ -75,6 +75,10 @@ public:
     // Invalidates the user settings cache.
     bool setUserSetting(const String& key, const String& value, std::function<void(bool)> callback = nullptr);
 
+    // Set robot navigation mode via "SetNavigationMode <mode>".
+    // Valid modes: "Normal", "Gentle", "Deep", "Quick".
+    bool setNavigationMode(const String& mode, std::function<void(bool)> callback = nullptr);
+
     // Power control: sends TestMode On, then SetSystemMode after inter-command delay.
     // action = "restart" (PowerCycle) or "shutdown" (Shutdown).
     bool powerControl(const String& action, std::function<void(bool)> callback = nullptr);
@@ -110,6 +114,11 @@ public:
     // Used by CleaningHistory to switch to active polling immediately.
     void onCleanStart(std::function<void()> cb) { cleanStartCallback = cb; }
 
+    // -- Navigation mode getter ----------------------------------------------
+    // Called from clean() before house clean to send SetNavigationMode.
+    // Returns the stored nav mode string (e.g. "Normal", "Gentle").
+    void setNavModeGetter(std::function<String()> getter) { navModeGetter = getter; }
+
     // -- Status --------------------------------------------------------------
 
     bool isBusy() const { return state != QUEUE_IDLE || !queue.empty(); }
@@ -143,6 +152,9 @@ private:
 
     // Clean start hook
     std::function<void()> cleanStartCallback;
+
+    // Navigation mode getter (reads from SettingsManager)
+    std::function<String()> navModeGetter;
 
     // Current command in flight
     String currentCommand;

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -58,6 +58,7 @@ void SettingsManager::load() {
     current.wifiTxPower = prefs.getInt(NVS_KEY_WIFI_TX_POWER, WIFI_DEFAULT_TX_POWER);
     current.uartTxPin = prefs.getInt(NVS_KEY_UART_TX_PIN, NEATO_DEFAULT_TX_PIN);
     current.uartRxPin = prefs.getInt(NVS_KEY_UART_RX_PIN, NEATO_DEFAULT_RX_PIN);
+    current.navMode = prefs.getString(NVS_KEY_NAV_MODE, "Normal");
     current.stallThreshold = prefs.getInt(NVS_KEY_MC_STALL_THR, MANUAL_STALL_LOAD_PCT);
     current.brushRpm = prefs.getInt(NVS_KEY_MC_BRUSH_RPM, MANUAL_BRUSH_RPM);
     current.vacuumSpeed = prefs.getInt(NVS_KEY_MC_VACUUM_PCT, MANUAL_VACUUM_SPEED_PCT);
@@ -85,6 +86,7 @@ void SettingsManager::save() {
     prefs.putInt(NVS_KEY_WIFI_TX_POWER, current.wifiTxPower);
     prefs.putInt(NVS_KEY_UART_TX_PIN, current.uartTxPin);
     prefs.putInt(NVS_KEY_UART_RX_PIN, current.uartRxPin);
+    prefs.putString(NVS_KEY_NAV_MODE, current.navMode);
     prefs.putInt(NVS_KEY_MC_STALL_THR, current.stallThreshold);
     prefs.putInt(NVS_KEY_MC_BRUSH_RPM, current.brushRpm);
     prefs.putInt(NVS_KEY_MC_VACUUM_PCT, current.vacuumSpeed);
@@ -208,6 +210,18 @@ ApplyResult SettingsManager::apply(const String& json) {
         LOG("SETTINGS", "UART RX pin -> GPIO%d (reboot required)", current.uartRxPin);
     }
 
+    // Cleaning — navigation mode (sent to robot before each house clean)
+    if (incoming.navMode != current.navMode) {
+        // Validate against known modes
+        if (incoming.navMode == "Normal" || incoming.navMode == "Gentle" || incoming.navMode == "Deep" ||
+            incoming.navMode == "Quick") {
+            current.navMode = incoming.navMode;
+            changed = true;
+            LOG("SETTINGS", "Nav mode -> %s", current.navMode.c_str());
+        }
+        // Silently ignore invalid values (keep current)
+    }
+
     // Manual clean motor settings — clamp to safe hardware ranges
     if (incoming.stallThreshold != current.stallThreshold) {
         current.stallThreshold = constrain(incoming.stallThreshold, 30, 80);
@@ -307,6 +321,7 @@ std::vector<Field> Settings::toFields() const {
             {"uartTxPin", String(uartTxPin), FIELD_INT},
             {"uartRxPin", String(uartRxPin), FIELD_INT},
             {"maxGpioPin", String(MAX_GPIO_PIN), FIELD_INT},
+            {"navMode", navMode, FIELD_STRING},
             {"stallThreshold", String(stallThreshold), FIELD_INT},
             {"brushRpm", String(brushRpm), FIELD_INT},
             {"vacuumSpeed", String(vacuumSpeed), FIELD_INT},
@@ -360,6 +375,10 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
     }
     if ((f = findField(fields, "uartRxPin")) && f->type == FIELD_INT) {
         uartRxPin = f->value.toInt();
+        applied = true;
+    }
+    if ((f = findField(fields, "navMode")) && f->type == FIELD_STRING) {
+        navMode = f->value;
         applied = true;
     }
     if ((f = findField(fields, "stallThreshold")) && f->type == FIELD_INT) {

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -27,6 +27,8 @@ struct Settings : public JsonSerializable {
     int wifiTxPower = WIFI_DEFAULT_TX_POWER; // 0.25 dBm units (34 = 8.5 dBm)
     int uartTxPin = NEATO_DEFAULT_TX_PIN; // ESP GPIO -> Robot RX
     int uartRxPin = NEATO_DEFAULT_RX_PIN; // ESP GPIO <- Robot TX
+    // House cleaning — sent to robot before each house clean starts
+    String navMode = "Normal"; // Navigation mode: "Normal", "Gentle", "Deep", "Quick"
     // Manual clean motor settings
     int stallThreshold = MANUAL_STALL_LOAD_PCT; // Wheel load % for stall detection (30-80)
     int brushRpm = MANUAL_BRUSH_RPM; // Main brush RPM (500-1600)

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -245,6 +245,7 @@ const state = {
     uartRxPin: 4,
     maxGpioPin: 21,
     hostname: "neato",
+    navMode: "Normal",
     stallThreshold: 60,
     brushRpm: 1200,
     vacuumSpeed: 80,
@@ -739,6 +740,7 @@ const routes = {
             "uartRxPin",
             "maxGpioPin",
             "hostname",
+            "navMode",
             "stallThreshold",
             "brushRpm",
             "vacuumSpeed",
@@ -1055,6 +1057,7 @@ const handleRequest = async (req, res) => {
             if (data.uartRxPin !== undefined) state.uartRxPin = data.uartRxPin;
             const hostnameChanged = data.hostname !== undefined && data.hostname !== state.hostname;
             if (data.hostname !== undefined) state.hostname = data.hostname;
+            if (data.navMode !== undefined) state.navMode = data.navMode;
             if (data.stallThreshold !== undefined) state.stallThreshold = data.stallThreshold;
             if (data.brushRpm !== undefined) state.brushRpm = data.brushRpm;
             if (data.vacuumSpeed !== undefined) state.vacuumSpeed = data.vacuumSpeed;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -53,6 +53,7 @@ export interface SettingsData {
     uartRxPin: number;
     maxGpioPin: number; // Read-only — max valid GPIO for this chip (21 for C3, 39 for ESP32)
     hostname: string;
+    navMode: string; // Navigation mode for house cleaning: "Normal", "Gentle", "Deep", "Quick"
     stallThreshold: number; // Wheel load % for stall detection (30-80)
     brushRpm: number; // Main brush RPM (500-1600)
     vacuumSpeed: number; // Vacuum speed % (40-100)

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -7,6 +7,7 @@ import calendarSvg from "../assets/icons/calendar.svg?raw";
 import chipSvg from "../assets/icons/chip.svg?raw";
 import databaseSvg from "../assets/icons/database.svg?raw";
 import gearSvg from "../assets/icons/gear.svg?raw";
+import houseSvg from "../assets/icons/house.svg?raw";
 import manualSvg from "../assets/icons/manual.svg?raw";
 import moonSvg from "../assets/icons/moon.svg?raw";
 import paletteSvg from "../assets/icons/palette.svg?raw";
@@ -25,6 +26,7 @@ import { usePolling } from "../hooks/use-polling";
 import type { FirmwareVersion, SystemData, UserSettingsData } from "../types";
 import {
     BRUSH_PRESETS,
+    NAV_MODE_PRESETS,
     SIDE_BRUSH_PRESETS,
     STALL_PRESETS,
     TIMEZONE_PRESETS,
@@ -85,6 +87,8 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         maxGpioPin,
         hostname,
         setHostname,
+        navMode,
+        setNavMode,
         stallThreshold,
         setStallThreshold,
         brushRpm,
@@ -572,6 +576,30 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                                 </div>
                             </>
                         )}
+                    </div>
+                </SettingsCategory>
+
+                <SettingsCategory title="House Cleaning" icon={houseSvg} disabled={firmware?.supported === false}>
+                    <div class="settings-section">
+                        <div class="settings-section-title">Navigation</div>
+                        <div class="settings-tz-select-wrap">
+                            <select
+                                class="settings-tz-select"
+                                value={navMode}
+                                onChange={(e) => setNavMode((e.target as HTMLSelectElement).value)}
+                                disabled={saving}
+                            >
+                                {NAV_MODE_PRESETS.map((p) => (
+                                    <option key={p.value} value={p.value}>
+                                        {p.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div class="settings-robot-time">
+                            How the robot navigates during house cleaning. Extra Care avoids obstacles, Deep cleans
+                            corners thoroughly.
+                        </div>
                     </div>
                 </SettingsCategory>
 

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -43,6 +43,19 @@ export const TX_POWER_PRESETS: TxPowerPreset[] = [
     { label: "19.5 dBm (max range)", value: 78 },
 ];
 
+// Navigation mode presets — sent to robot before each house clean
+export interface NavModePreset {
+    label: string;
+    value: string;
+}
+
+export const NAV_MODE_PRESETS: NavModePreset[] = [
+    { label: "Normal", value: "Normal" },
+    { label: "Extra Care", value: "Gentle" },
+    { label: "Deep", value: "Deep" },
+    { label: "Quick", value: "Quick" },
+];
+
 // Stall detection presets — wheel load % threshold
 export interface StallPreset {
     label: string;
@@ -107,6 +120,7 @@ export const DEFAULT_SERVER = {
     uartRxPin: 4,
     maxGpioPin: 21,
     hostname: "neato",
+    navMode: "Normal",
     stallThreshold: 60,
     brushRpm: 1200,
     vacuumSpeed: 80,

--- a/frontend/src/views/settings/use-settings-form.ts
+++ b/frontend/src/views/settings/use-settings-form.ts
@@ -14,6 +14,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     const [uartRxPin, setUartRxPin] = useState(4);
     const [maxGpioPin, setMaxGpioPin] = useState(21);
     const [hostname, setHostname] = useState("neato");
+    const [navMode, setNavMode] = useState("Normal");
     const [stallThreshold, setStallThreshold] = useState(60);
     const [brushRpm, setBrushRpm] = useState(1200);
     const [vacuumSpeed, setVacuumSpeed] = useState(80);
@@ -46,6 +47,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
             setUartRxPin(fetched.uartRxPin);
             setMaxGpioPin(fetched.maxGpioPin);
             setHostname(fetched.hostname);
+            setNavMode(fetched.navMode ?? "Normal");
             setStallThreshold(fetched.stallThreshold);
             setBrushRpm(fetched.brushRpm);
             setVacuumSpeed(fetched.vacuumSpeed);
@@ -70,6 +72,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
             uartTxPin !== server.current.uartTxPin ||
             uartRxPin !== server.current.uartRxPin ||
             hostname !== server.current.hostname ||
+            navMode !== (server.current.navMode ?? "Normal") ||
             stallThreshold !== server.current.stallThreshold ||
             brushRpm !== server.current.brushRpm ||
             vacuumSpeed !== server.current.vacuumSpeed ||
@@ -114,6 +117,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         if (uartTxPin !== server.current.uartTxPin) patch.uartTxPin = uartTxPin;
         if (uartRxPin !== server.current.uartRxPin) patch.uartRxPin = uartRxPin;
         if (hostname !== server.current.hostname) patch.hostname = hostname;
+        if (navMode !== (server.current.navMode ?? "Normal")) patch.navMode = navMode;
         if (stallThreshold !== server.current.stallThreshold) patch.stallThreshold = stallThreshold;
         if (brushRpm !== server.current.brushRpm) patch.brushRpm = brushRpm;
         if (vacuumSpeed !== server.current.vacuumSpeed) patch.vacuumSpeed = vacuumSpeed;
@@ -132,6 +136,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         uartTxPin,
         uartRxPin,
         hostname,
+        navMode,
         stallThreshold,
         brushRpm,
         vacuumSpeed,
@@ -192,6 +197,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         maxGpioPin,
         hostname,
         setHostname,
+        navMode,
+        setNavMode,
         stallThreshold,
         setStallThreshold,
         brushRpm,


### PR DESCRIPTION
## Summary

- New "House Cleaning" section in Settings with navigation mode dropdown (Normal, Extra Care, Deep, Quick)
- Navigation mode stored in NVS and automatically sent to robot before each house clean
- Tested on D7 firmware 4.6.0 via `SetNavigationMode` serial command

Closes #77