### PR TITLE
Add remote syslog (UDP) logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,9 @@ Three top-level components: `firmware/` (ESP32 C/C++), `frontend/` (Preact SPA),
 Logging is controlled by `logLevel` in settings (0=off, 1=info, 2=debug). Default
 is **off** - nothing written to SPIFFS. Both info and debug auto-revert to off
 after a timeout (1 hour / 10 minutes) to prevent forgotten logging from degrading
-serial performance.
+serial performance. When remote syslog is enabled (`syslogEnabled`), logs are sent
+over UDP (port 514, BSD syslog format) instead of flash, and the auto-expire timer
+is disabled.
 
 All significant events must be logged via `DataLogger` (injected by reference).
 `logEvent` is private — use typed public helpers (`logRequest`, `logWifi`, `logOta`,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ port, giving you a local web interface that works without any external dependenc
   brush), bumper/wheel-lift/stall safety warnings
 - **Live cleaning map** — watch the robot's path during an active cleaning session in the History view, rendered on a
   canvas with coverage overlay
-- **7-day cleaning scheduler** with two slots per day, managed entirely on the ESP32 (doesn't use the robot's built-in schedule commands)
+- **7-day cleaning scheduler** with two slots per day, managed entirely on the ESP32 (doesn't use the robot's built-in
+  schedule commands)
 - **Cleaning history** with recorded robot paths rendered as coverage maps, session stats like duration, distance, area
   covered, and battery usage; individual session import/export for backup and restore
 - **Push notifications** via [ntfy.sh](https://ntfy.sh); get notified when cleaning is done, an error occurs, a
@@ -50,7 +51,8 @@ port, giving you a local web interface that works without any external dependenc
 - **Settings page** for hostname, timezone, motor presets, notification topics, UART pins, theme (dark/light/auto), and
   more
 - **Event logging** with configurable log levels (off/info/debug), compressed JSONL files on SPIFFS, browsable and
-  downloadable from the UI; logging is off by default to minimize flash wear
+  downloadable from the UI; optional remote syslog (UDP) for long-running diagnostics without flash wear; logging is
+  off by default
 - **Factory reset** via 5-second button hold on the ESP32 or from the settings page
 - **Robot clock sync** — pushes NTP time to the robot automatically, re-syncs every 4 hours
 - **Flash tool** — standalone CLI that auto-detects the USB port, downloads the correct firmware from GitHub Releases,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -328,9 +328,17 @@ Go to **Settings -> Diagnostics** and set **Log Level**:
 - **Debug** — everything in Info plus all serial commands with raw responses. Auto-reverts to
   off after 10 minutes.
 
+For long-running diagnostics (e.g. catching an intermittent error that only appears after
+hours of idling), enable **Remote Syslog** in the same section. This sends all log output
+over UDP (port 514) to a syslog receiver on your network instead of writing to flash. The
+auto-expire timer is disabled when remote syslog is active, so logging continues until you
+turn it off. Enter the IPv4 address of your syslog receiver (e.g. a machine running
+`rsyslog`, `syslog-ng`, or any UDP syslog listener).
+
 > [!NOTE]
-> Logging writes to flash storage (SPIFFS). Higher levels generate more writes, which
-> increases flash wear. Use Info or Debug only when actively diagnosing an issue.
+> When remote syslog is off, logging writes to flash storage (SPIFFS). Higher levels generate
+> more writes, which increases flash wear. Use Info or Debug only when actively diagnosing an
+> issue.
 
 ### Collecting Logs
 
@@ -375,9 +383,11 @@ Two ways to factory reset:
 
 Before creating an issue on GitHub:
 
-1. **Set log level to Debug** (Settings -> Diagnostics -> Log Level -> Debug)
+1. **Set log level to Debug** (Settings -> Diagnostics -> Log Level -> Debug). For intermittent
+   issues, enable **Remote Syslog** so logging persists without flash wear or auto-expire.
 2. **Reproduce the problem** while logging is active
-3. **Download the logs** (Settings -> Diagnostics -> Logs)
+3. **Download the logs** (Settings -> Diagnostics -> Logs), or copy the relevant lines from
+   your syslog receiver if using remote syslog
 4. **If the issue involves cleaning**: download the relevant cleaning session from History
 5. Create an issue at [github.com/renjfk/OpenNeato/issues](https://github.com/renjfk/OpenNeato/issues)
    and attach the log files

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -137,6 +137,12 @@ enum CommandStatus {
 #define NVS_KEY_MC_VACUUM_PCT "mc_vacuum_pct"
 #define NVS_KEY_MC_SBRUSH_MW "mc_sbrush_mw"
 
+// NVS keys — Remote syslog
+#define NVS_KEY_SYSLOG_ENABLED "syslog_on"
+#define NVS_KEY_SYSLOG_IP "syslog_ip"
+#define SYSLOG_DEFAULT_PORT 514
+#define SYSLOG_PRI "<14>" // facility=user (1), severity=info (6) -> 1*8+6=14
+
 // NVS keys — Notifications
 #define NVS_KEY_NTFY_TOPIC "ntfy_topic"
 #define NVS_KEY_NTFY_ENABLED "ntfy_enabled"

--- a/firmware/src/data_logger.cpp
+++ b/firmware/src/data_logger.cpp
@@ -411,6 +411,23 @@ void DataLogger::enforceLimits() {
     }
 }
 
+// -- UDP syslog sender -------------------------------------------------------
+
+void DataLogger::sendSyslog(const String& line) {
+    if (!syslogCheck)
+        return;
+    auto cfg = syslogCheck();
+    if (!cfg.enabled || cfg.ip.isEmpty())
+        return;
+
+    // BSD syslog format (RFC 3164): <PRI>HOSTNAME APP: MESSAGE
+    // Keep it minimal — the JSON line is the message payload
+    String packet = String(SYSLOG_PRI) + "openneato: " + line;
+    syslogUdp.beginPacket(cfg.ip.c_str(), SYSLOG_DEFAULT_PORT);
+    syslogUdp.write(reinterpret_cast<const uint8_t *>(packet.c_str()), packet.length());
+    syslogUdp.endPacket();
+}
+
 // -- Public logging methods --------------------------------------------------
 
 void DataLogger::logEvent(const String& type, const std::vector<Field>& fields) {
@@ -421,6 +438,16 @@ void DataLogger::logEvent(const String& type, const std::vector<Field>& fields) 
 
     String line = "{\"t\":" + String(static_cast<long>(sysMgr.now())) + ",\"typ\":\"" + type + "\",\"d\":{" +
                   fieldsToJsonInner(fields) + "}}";
+
+    // Route to syslog (UDP) or flash buffer based on syslog setting.
+    // When syslog is enabled, skip flash writes entirely to avoid wear.
+    if (syslogCheck) {
+        auto cfg = syslogCheck();
+        if (cfg.enabled && !cfg.ip.isEmpty()) {
+            sendSyslog(line);
+            return;
+        }
+    }
     bufferLine(line);
 }
 

--- a/firmware/src/data_logger.h
+++ b/firmware/src/data_logger.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <ESPAsyncWebServer.h>
 #include <SPIFFS.h>
+#include <WiFiUdp.h>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -104,6 +105,15 @@ public:
     using LogLevelCheck = std::function<int()>;
     void setLogLevelCheck(LogLevelCheck check) { logLevelCheck = check; }
 
+    // Syslog check — returns whether syslog is enabled and the target host.
+    // When enabled, log output goes to UDP instead of flash.
+    struct SyslogConfig {
+        bool enabled = false;
+        String ip;
+    };
+    using SyslogCheck = std::function<SyslogConfig()>;
+    void setSyslogCheck(SyslogCheck check) { syslogCheck = check; }
+
     // -- Log file management (for API) --------------------------------------
 
     std::vector<LogFileInfo> listLogs();
@@ -117,6 +127,11 @@ private:
     NeatoSerial& neato;
     SystemManager& sysMgr;
     LogLevelCheck logLevelCheck;
+    SyslogCheck syslogCheck;
+
+    // UDP syslog sender — fire-and-forget, no ack
+    WiFiUDP syslogUdp;
+    void sendSyslog(const String& line);
 
     void logEvent(const String& type, const std::vector<Field>& fields);
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -136,6 +136,13 @@ void setup() {
     // Note: WiFi/OTA events buffered in memory above get flushed once SPIFFS mounts here.
     LOG("BOOT", "Initializing data logger...");
     dataLogger.setLogLevelCheck([&]() { return settingsManager.get().logLevel; });
+    dataLogger.setSyslogCheck([&]() -> DataLogger::SyslogConfig {
+        const auto& cfg = settingsManager.get();
+        DataLogger::SyslogConfig sc;
+        sc.enabled = cfg.syslogEnabled;
+        sc.ip = cfg.syslogIp;
+        return sc;
+    });
     dataLogger.begin();
 
     // Fetch robot time as fallback clock (parsed from "Time UTC" in GetVersion)

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -63,6 +63,8 @@ void SettingsManager::load() {
     current.brushRpm = prefs.getInt(NVS_KEY_MC_BRUSH_RPM, MANUAL_BRUSH_RPM);
     current.vacuumSpeed = prefs.getInt(NVS_KEY_MC_VACUUM_PCT, MANUAL_VACUUM_SPEED_PCT);
     current.sideBrushPower = prefs.getInt(NVS_KEY_MC_SBRUSH_MW, MANUAL_SIDE_BRUSH_POWER_MW);
+    current.syslogEnabled = prefs.getBool(NVS_KEY_SYSLOG_ENABLED, false);
+    current.syslogIp = prefs.getString(NVS_KEY_SYSLOG_IP, "");
     current.ntfyTopic = prefs.getString(NVS_KEY_NTFY_TOPIC, "");
     current.ntfyEnabled = prefs.getBool(NVS_KEY_NTFY_ENABLED, false);
     current.ntfyOnDone = prefs.getBool(NVS_KEY_NTFY_ON_DONE, true);
@@ -91,6 +93,8 @@ void SettingsManager::save() {
     prefs.putInt(NVS_KEY_MC_BRUSH_RPM, current.brushRpm);
     prefs.putInt(NVS_KEY_MC_VACUUM_PCT, current.vacuumSpeed);
     prefs.putInt(NVS_KEY_MC_SBRUSH_MW, current.sideBrushPower);
+    prefs.putBool(NVS_KEY_SYSLOG_ENABLED, current.syslogEnabled);
+    prefs.putString(NVS_KEY_SYSLOG_IP, current.syslogIp);
     prefs.putString(NVS_KEY_NTFY_TOPIC, current.ntfyTopic);
     prefs.putBool(NVS_KEY_NTFY_ENABLED, current.ntfyEnabled);
     prefs.putBool(NVS_KEY_NTFY_ON_DONE, current.ntfyOnDone);
@@ -112,7 +116,9 @@ void SettingsManager::save() {
 const Settings& SettingsManager::get() {
     // Auto-revert log level to off after timeout to prevent forgotten verbose
     // logging that fills flash and degrades serial performance.
-    if (current.logLevel > LOG_LEVEL_OFF && logLevelEnabledAt > 0) {
+    // Skip auto-expire when syslog is enabled — syslog sends over UDP so there
+    // is no flash wear concern, and the whole point is long-running capture.
+    if (current.logLevel > LOG_LEVEL_OFF && logLevelEnabledAt > 0 && !current.syslogEnabled) {
         unsigned long timeout =
                 (current.logLevel >= LOG_LEVEL_DEBUG) ? LOG_LEVEL_AUTO_OFF_DEBUG_MS : LOG_LEVEL_AUTO_OFF_INFO_MS;
         if (millis() - logLevelEnabledAt >= timeout) {
@@ -244,6 +250,17 @@ ApplyResult SettingsManager::apply(const String& json) {
         LOG("SETTINGS", "Side brush power -> %d mW", current.sideBrushPower);
     }
 
+    if (incoming.syslogEnabled != current.syslogEnabled) {
+        current.syslogEnabled = incoming.syslogEnabled;
+        changed = true;
+        LOG("SETTINGS", "Syslog -> %s", current.syslogEnabled ? "on" : "off");
+    }
+    if (incoming.syslogIp != current.syslogIp) {
+        current.syslogIp = incoming.syslogIp;
+        changed = true;
+        LOG("SETTINGS", "Syslog host -> %s", current.syslogIp.isEmpty() ? "(empty)" : current.syslogIp.c_str());
+    }
+
     if (incoming.ntfyTopic != current.ntfyTopic) {
         current.ntfyTopic = incoming.ntfyTopic;
         changed = true;
@@ -326,6 +343,8 @@ std::vector<Field> Settings::toFields() const {
             {"brushRpm", String(brushRpm), FIELD_INT},
             {"vacuumSpeed", String(vacuumSpeed), FIELD_INT},
             {"sideBrushPower", String(sideBrushPower), FIELD_INT},
+            {"syslogEnabled", syslogEnabled ? "true" : "false", FIELD_BOOL},
+            {"syslogIp", syslogIp, FIELD_STRING},
             {"ntfyTopic", ntfyTopic, FIELD_STRING},
             {"ntfyEnabled", ntfyEnabled ? "true" : "false", FIELD_BOOL},
             {"ntfyOnDone", ntfyOnDone ? "true" : "false", FIELD_BOOL},
@@ -395,6 +414,14 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
     }
     if ((f = findField(fields, "sideBrushPower")) && f->type == FIELD_INT) {
         sideBrushPower = f->value.toInt();
+        applied = true;
+    }
+    if ((f = findField(fields, "syslogEnabled")) && f->type == FIELD_BOOL) {
+        syslogEnabled = (f->value == "true");
+        applied = true;
+    }
+    if ((f = findField(fields, "syslogIp")) && f->type == FIELD_STRING) {
+        syslogIp = f->value;
         applied = true;
     }
     if ((f = findField(fields, "ntfyTopic")) && f->type == FIELD_STRING) {

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -35,6 +35,10 @@ struct Settings : public JsonSerializable {
     int vacuumSpeed = MANUAL_VACUUM_SPEED_PCT; // Vacuum speed % (40-100)
     int sideBrushPower = MANUAL_SIDE_BRUSH_POWER_MW; // Side brush power in mW (500-1500)
 
+    // Remote syslog (UDP) — when enabled, logs go to network instead of flash
+    bool syslogEnabled = false;
+    String syslogIp; // IPv4 address of syslog receiver
+
     // Notifications (ntfy.sh)
     String ntfyTopic; // Empty = disabled
     bool ntfyEnabled = false; // Global switch — must be on for any notification to fire

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -240,6 +240,8 @@ const state = {
     lidarSlowRotation: false,
     tz: "UTC0",
     logLevel: 0,
+    syslogEnabled: false,
+    syslogIp: "",
     wifiTxPower: 60, // 15 dBm in 0.25 dBm units
     uartTxPin: 3,
     uartRxPin: 4,
@@ -735,6 +737,8 @@ const routes = {
         const keys = [
             "tz",
             "logLevel",
+            "syslogEnabled",
+            "syslogIp",
             "wifiTxPower",
             "uartTxPin",
             "uartRxPin",
@@ -1049,6 +1053,8 @@ const handleRequest = async (req, res) => {
             await new Promise((r) => setTimeout(r, rand(300, 600)));
             if (data.tz !== undefined) state.tz = data.tz;
             if (data.logLevel !== undefined) state.logLevel = data.logLevel;
+            if (data.syslogEnabled !== undefined) state.syslogEnabled = data.syslogEnabled;
+            if (data.syslogIp !== undefined) state.syslogIp = data.syslogIp;
             if (data.wifiTxPower !== undefined) state.wifiTxPower = data.wifiTxPower;
             const pinsChanged =
                 (data.uartTxPin !== undefined && data.uartTxPin !== state.uartTxPin) ||
@@ -1087,6 +1093,8 @@ const handleRequest = async (req, res) => {
             const keys = [
                 "tz",
                 "logLevel",
+                "syslogEnabled",
+                "syslogIp",
                 "wifiTxPower",
                 "uartTxPin",
                 "uartRxPin",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -48,6 +48,8 @@ export interface SystemData {
 export interface SettingsData {
     tz: string;
     logLevel: number; // 0=off, 1=info, 2=debug
+    syslogEnabled: boolean; // When on, logs go to UDP syslog instead of flash
+    syslogIp: string; // IPv4 address of syslog receiver
     wifiTxPower: number; // 0.25 dBm units (e.g. 34 = 8.5 dBm)
     uartTxPin: number;
     uartRxPin: number;

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -78,6 +78,10 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         setTz,
         logLevel,
         setLogLevel,
+        syslogEnabled,
+        setSyslogEnabled,
+        syslogIp,
+        setSyslogIp,
         wifiTxPower,
         setWifiTxPower,
         uartTxPin,
@@ -112,6 +116,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         isDirty,
         pinError,
         hostnameError,
+        syslogIpError,
         validationError,
         saving,
         showSaveConfirm,
@@ -808,14 +813,45 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                                 disabled={saving}
                             >
                                 <option value={0}>Off (default)</option>
-                                <option value={1}>Info (auto-off after 1 hour)</option>
-                                <option value={2}>Debug (auto-off after 10 min)</option>
+                                <option value={1}>{syslogEnabled ? "Info" : "Info (auto-off after 1 hour)"}</option>
+                                <option value={2}>{syslogEnabled ? "Debug" : "Debug (auto-off after 10 min)"}</option>
                             </select>
                         </div>
                         <div class="settings-robot-time">
-                            Logging writes to flash storage. Higher levels increase wear and can slow serial
-                            communication.
+                            {syslogEnabled
+                                ? "Logs are sent to the remote syslog server over UDP."
+                                : "Logging writes to flash storage. Higher levels increase wear and can slow serial communication."}
                         </div>
+                    </div>
+                    <div class="settings-section">
+                        <div class="settings-toggle-row">
+                            <div class="settings-toggle-label">
+                                <span class="settings-toggle-title">Remote syslog</span>
+                                <span class="settings-toggle-desc">Send logs over UDP instead of writing to flash</span>
+                            </div>
+                            <button
+                                type="button"
+                                class={`settings-toggle${syslogEnabled ? " on" : ""}`}
+                                onClick={() => setSyslogEnabled(!syslogEnabled)}
+                                disabled={saving}
+                                aria-label="Toggle remote syslog"
+                            />
+                        </div>
+                        {syslogEnabled && (
+                            <>
+                                <div class="settings-ntfy-row">
+                                    <input
+                                        type="text"
+                                        class="settings-text-input"
+                                        value={syslogIp}
+                                        onInput={(e) => setSyslogIp((e.target as HTMLInputElement).value)}
+                                        disabled={saving}
+                                        placeholder="e.g. 192.168.1.100"
+                                    />
+                                </div>
+                                {syslogIpError && <div class="settings-field-error">{syslogIpError}</div>}
+                            </>
+                        )}
                     </div>
                     <div class="settings-section">
                         <button type="button" class="settings-nav-row" onClick={() => guardedNavigate("/logs")}>

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -115,6 +115,8 @@ export const SIDE_BRUSH_PRESETS: SideBrushPreset[] = [
 export const DEFAULT_SERVER = {
     tz: "UTC0",
     logLevel: 0,
+    syslogEnabled: false,
+    syslogIp: "",
     wifiTxPower: 60,
     uartTxPin: 3,
     uartRxPin: 4,

--- a/frontend/src/views/settings/use-settings-form.ts
+++ b/frontend/src/views/settings/use-settings-form.ts
@@ -9,6 +9,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     // Local form state
     const [tz, setTz] = useState<string>("UTC0");
     const [logLevel, setLogLevel] = useState(0);
+    const [syslogEnabled, setSyslogEnabled] = useState(false);
+    const [syslogIp, setSyslogIp] = useState("");
     const [wifiTxPower, setWifiTxPower] = useState(60);
     const [uartTxPin, setUartTxPin] = useState(3);
     const [uartRxPin, setUartRxPin] = useState(4);
@@ -42,6 +44,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
             server.current = { ...fetched };
             setTz(fetched.tz);
             setLogLevel(fetched.logLevel);
+            setSyslogEnabled(fetched.syslogEnabled ?? false);
+            setSyslogIp(fetched.syslogIp ?? "");
             setWifiTxPower(fetched.wifiTxPower);
             setUartTxPin(fetched.uartTxPin);
             setUartRxPin(fetched.uartRxPin);
@@ -68,6 +72,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         settingsLoaded &&
         (tz !== server.current.tz ||
             logLevel !== server.current.logLevel ||
+            syslogEnabled !== (server.current.syslogEnabled ?? false) ||
+            syslogIp !== (server.current.syslogIp ?? "") ||
             wifiTxPower !== server.current.wifiTxPower ||
             uartTxPin !== server.current.uartTxPin ||
             uartRxPin !== server.current.uartRxPin ||
@@ -105,7 +111,17 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
                 ? "Only letters, numbers, and hyphens"
                 : null;
 
-    const validationError = pinError || hostnameError;
+    const isValidIpv4 = (ip: string) => /^(\d{1,3}\.){3}\d{1,3}$/.test(ip) && ip.split(".").every((n) => +n <= 255);
+
+    const syslogIpError = syslogEnabled
+        ? syslogIp.trim().length === 0
+            ? "IP address is required when syslog is enabled"
+            : !isValidIpv4(syslogIp.trim())
+              ? "Must be a valid IPv4 address"
+              : null
+        : null;
+
+    const validationError = pinError || hostnameError || syslogIpError;
 
     // --- Unified save ---
 
@@ -113,6 +129,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         const patch: Partial<SettingsData> = {};
         if (tz !== server.current.tz) patch.tz = tz;
         if (logLevel !== server.current.logLevel) patch.logLevel = logLevel;
+        if (syslogEnabled !== (server.current.syslogEnabled ?? false)) patch.syslogEnabled = syslogEnabled;
+        if (syslogIp !== (server.current.syslogIp ?? "")) patch.syslogIp = syslogIp;
         if (wifiTxPower !== server.current.wifiTxPower) patch.wifiTxPower = wifiTxPower;
         if (uartTxPin !== server.current.uartTxPin) patch.uartTxPin = uartTxPin;
         if (uartRxPin !== server.current.uartRxPin) patch.uartRxPin = uartRxPin;
@@ -132,6 +150,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     }, [
         tz,
         logLevel,
+        syslogEnabled,
+        syslogIp,
         wifiTxPower,
         uartTxPin,
         uartRxPin,
@@ -188,6 +208,10 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         setTz,
         logLevel,
         setLogLevel,
+        syslogEnabled,
+        setSyslogEnabled,
+        syslogIp,
+        setSyslogIp,
         wifiTxPower,
         setWifiTxPower,
         uartTxPin,
@@ -224,6 +248,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         needsReboot,
         pinError,
         hostnameError,
+        syslogIpError,
         validationError,
         // Save flow
         saving,


### PR DESCRIPTION
## Summary

- Remote syslog option under Settings > Diagnostics sends logs over UDP (port 514) instead of flash
- When enabled, auto-expire timer is disabled and flash writes are skipped
- Log level labels update dynamically when syslog is active
- IPv4 validation on syslog IP field

Closes #80