### PR TITLE
Fix left/right mirrored obstacle view in manual mode LIDAR map

### DIFF
--- a/frontend/src/components/lidar-map.tsx
+++ b/frontend/src/components/lidar-map.tsx
@@ -113,7 +113,7 @@ export function LidarMap({ scan, size, moving }: LidarMapProps) {
 
         // Helper: angle to canvas coordinates
         const toCanvas = (angleDeg: number, dist: number): [number, number] => {
-            const rad = ((90 - angleDeg) * Math.PI) / 180;
+            const rad = ((90 + angleDeg) * Math.PI) / 180;
             return [cx + dist * scale * Math.cos(rad), cy - dist * scale * Math.sin(rad)];
         };
 


### PR DESCRIPTION
## Summary
- Fix horizontal mirroring of LDS obstacle data in the manual mode map view
- Correct the polar-to-canvas angle conversion in the LIDAR map component

Fixes #82