### PR TITLE
feat: motion player to replay cleaning sessions

### DIFF
--- a/frontend/src/assets/icons/restart.svg
+++ b/frontend/src/assets/icons/restart.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><rect x="5" y="5" width="2.5" height="14" rx="0.5"/><path d="M20 5 9 12l11 7V5z"/></svg>

--- a/frontend/src/history-data.ts
+++ b/frontend/src/history-data.ts
@@ -1,7 +1,15 @@
 // Map data processing — parses raw JSONL from firmware and generates
 // coverage maps, path arrays, and bounding boxes client-side.
 
-import type { MapBounds, MapData, MapPathPoint, MapRechargePoint, MapSession, MapSummary } from "./types";
+import type {
+    MapBounds,
+    MapCoverageCell,
+    MapData,
+    MapPathPoint,
+    MapRechargePoint,
+    MapSession,
+    MapSummary,
+} from "./types";
 
 const ROBOT_DIAMETER_M = 0.33; // Neato Botvac diameter
 const CELL_SIZE_M = 0.05; // 5cm grid cells for coverage map
@@ -81,31 +89,95 @@ function isPose(l: SessionLine): l is RawPose {
 }
 
 function buildSession(lines: string[]): MapData {
+    // Preserve source order so recharges can be timestamped relative to
+    // the nearest pose snapshot (recharges don't carry their own ts field).
     const parsed: SessionLine[] = [];
+    const rawRecharges: { x: number; y: number; prevTs: number }[] = [];
+    let lastPoseTs = 0;
+
     for (const l of lines) {
+        let obj: SessionLine | null = null;
         try {
-            parsed.push(JSON.parse(l));
+            obj = JSON.parse(l);
         } catch {
-            // Attempt to recover corrupted pose lines before dropping
             const repaired = tryRepairPoseLine(l);
-            if (repaired) parsed.push(repaired);
+            if (repaired) obj = repaired;
+        }
+        if (!obj) continue;
+        parsed.push(obj);
+        if (isPose(obj)) {
+            lastPoseTs = obj.ts;
+        } else if (isRecharge(obj)) {
+            rawRecharges.push({ x: obj.x, y: obj.y, prevTs: lastPoseTs });
         }
     }
 
     const session: MapSession | null = parsed.find(isSession) ?? null;
     const summary: MapSummary | null = parsed.find(isSummary) ?? null;
-    const poses: RawPose[] = parsed.filter(isPose).filter((l) => l.x !== 0 || l.y !== 0 || l.t !== 0);
-    const recharges: MapRechargePoint[] = parsed.filter(isRecharge).map((l) => ({ x: l.x, y: l.y }));
+    const rawPoses: RawPose[] = parsed.filter(isPose).filter((l) => l.x !== 0 || l.y !== 0 || l.t !== 0);
 
-    if (poses.length === 0) {
-        return { session, summary, path: [], coverage: [], recharges, bounds: null, cellSize: CELL_SIZE_M };
+    if (rawPoses.length === 0) {
+        return { session, summary, path: [], coverage: [], recharges: [], bounds: null, cellSize: CELL_SIZE_M };
     }
+
+    // Firmware records `ts` as seconds since boot, not session start, so
+    // normalize against the first retained pose. This makes timestamps
+    // session-relative and keeps them in sync with the summary duration
+    // used by the motion player's scrubber.
+    const tOrigin = rawPoses[0].ts;
+    const poses: RawPose[] = rawPoses.map((p) => ({ ...p, ts: Math.max(0, p.ts - tOrigin) }));
+
+    // Detect charge windows from long gaps in the pose timeline. The firmware
+    // writes the recharge marker as soon as the robot starts docking, but
+    // keeps writing snapshots until collection is paused on the dock — so
+    // the gap containing the actual charge can be a handful of lines after
+    // the marker. We scan the whole pose timeline for big gaps (> a few
+    // typical snapshot intervals) and pair each recharge marker with its
+    // nearest gap for accurate start/end times.
+    const POSE_INTERVAL_S = 2; // firmware samples every ~2s
+    const GAP_MIN_S = 30; // anything longer than 15x the interval is a pause
+    const gaps: { start: number; end: number }[] = [];
+    for (let i = 1; i < poses.length; i++) {
+        const delta = poses[i].ts - poses[i - 1].ts;
+        if (delta >= GAP_MIN_S) {
+            gaps.push({ start: poses[i - 1].ts, end: poses[i].ts });
+        }
+    }
+
+    const usedGaps = new Set<number>();
+    const recharges: MapRechargePoint[] = rawRecharges.map((r) => {
+        const markerTs = Math.max(0, r.prevTs - tOrigin);
+        // Find the closest unused gap to the marker. Prefer one that starts
+        // at or after the marker since the pause always follows the marker.
+        let bestIdx = -1;
+        let bestScore = Infinity;
+        for (let i = 0; i < gaps.length; i++) {
+            if (usedGaps.has(i)) continue;
+            const g = gaps[i];
+            const distance = g.start >= markerTs ? g.start - markerTs : (markerTs - g.start) * 4;
+            if (distance < bestScore) {
+                bestScore = distance;
+                bestIdx = i;
+            }
+        }
+        if (bestIdx >= 0) {
+            usedGaps.add(bestIdx);
+            const g = gaps[bestIdx];
+            return { x: r.x, y: r.y, ts: g.start, endTs: g.end };
+        }
+        // Fallback when no large gap was found — use a single-interval window
+        // so the bar still shows a visible sliver at the marker location.
+        const next = poses.find((p) => p.ts > markerTs);
+        return { x: r.x, y: r.y, ts: markerTs, endTs: next ? next.ts : markerTs + POSE_INTERVAL_S };
+    });
 
     const path: MapPathPoint[] = poses.map((p) => ({ x: p.x, y: p.y, t: p.t, ts: p.ts }));
 
-    // Coverage grid — stamp robot footprint circle at each pose
+    // Coverage grid — stamp robot footprint circle at each pose and record
+    // the earliest timestamp at which the cell was touched so the motion
+    // player can reveal coverage progressively.
     const radiusCells = Math.ceil(ROBOT_DIAMETER_M / 2 / CELL_SIZE_M);
-    const coveredCells = new Set<string>();
+    const firstCoverTs = new Map<string, number>();
 
     for (const p of poses) {
         const cx = Math.round(p.x / CELL_SIZE_M);
@@ -113,15 +185,16 @@ function buildSession(lines: string[]): MapData {
         for (let dx = -radiusCells; dx <= radiusCells; dx++) {
             for (let dy = -radiusCells; dy <= radiusCells; dy++) {
                 if (dx * dx + dy * dy <= radiusCells * radiusCells) {
-                    coveredCells.add(`${cx + dx},${cy + dy}`);
+                    const key = `${cx + dx},${cy + dy}`;
+                    if (!firstCoverTs.has(key)) firstCoverTs.set(key, p.ts);
                 }
             }
         }
     }
 
-    const coverage: [number, number][] = Array.from(coveredCells).map((k) => {
+    const coverage: MapCoverageCell[] = Array.from(firstCoverTs.entries()).map(([k, ts]) => {
         const [c, r] = k.split(",").map(Number);
-        return [c, r];
+        return [c, r, ts];
     });
 
     // Bounding box padded by robot radius

--- a/frontend/src/hooks/use-fetch.ts
+++ b/frontend/src/hooks/use-fetch.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "preact/hooks";
+import { normalizeError } from "../utils";
 
 export interface FetchResult<T> {
     data: T | null;
@@ -22,7 +23,7 @@ export function useFetch<T>(fetcher: () => Promise<T>, deps: unknown[] = []): Fe
                 if (active) setData(result);
             })
             .catch((e: unknown) => {
-                if (active) setError(e instanceof Error ? e.message : "Fetch failed");
+                if (active) setError(normalizeError(e, "Fetch failed"));
             })
             .finally(() => {
                 if (active) setLoading(false);

--- a/frontend/src/hooks/use-key-shortcut.ts
+++ b/frontend/src/hooks/use-key-shortcut.ts
@@ -1,0 +1,72 @@
+import { useEffect } from "preact/hooks";
+
+// Which modifier keys a shortcut requires. Each flag means "this modifier
+// must be in the given state". Flags left undefined don't constrain the
+// match. `{}` means "no modifiers at all" — the default.
+export interface KeyModifiers {
+    ctrl?: boolean;
+    meta?: boolean;
+    alt?: boolean;
+    shift?: boolean;
+}
+
+export interface KeyShortcutOptions {
+    // Key to match — compared against KeyboardEvent.key (e.g. " ", "Escape",
+    // "ArrowLeft") and optionally KeyboardEvent.code (e.g. "Space").
+    key: string;
+    // Optional KeyboardEvent.code alternative when `key` alone is ambiguous
+    // (e.g. " " can mean the spacebar or another layout's key).
+    code?: string;
+    // Required modifier state. Omitted modifiers must be *not held*; set a
+    // modifier to `true` to require it, `false` to explicitly forbid it.
+    // Pass "any" to skip modifier checking entirely.
+    modifiers?: KeyModifiers | "any";
+    // When false the shortcut is inert. Useful to toggle the binding based
+    // on whether a view or modal is open.
+    enabled?: boolean;
+    // When true the handler fires even while the user is typing in an
+    // input/textarea/select/contentEditable element. Default is false so
+    // shortcuts don't steal legitimate text input.
+    fireInInputs?: boolean;
+    // When true (default) the browser's default action for the key is
+    // prevented when the shortcut fires.
+    preventDefault?: boolean;
+}
+
+function modifiersMatch(e: KeyboardEvent, mods: KeyModifiers | "any" | undefined): boolean {
+    if (mods === "any") return true;
+    const want = mods ?? {};
+    if ((want.ctrl ?? false) !== e.ctrlKey) return false;
+    if ((want.meta ?? false) !== e.metaKey) return false;
+    if ((want.alt ?? false) !== e.altKey) return false;
+    if ((want.shift ?? false) !== e.shiftKey) return false;
+    return true;
+}
+
+// Binds a single keyboard shortcut at the window level. Intended for simple
+// view-scoped accelerators (e.g. space to play/pause, escape to close). For
+// complex key handling or focus-scoped bindings use direct addEventListener.
+export function useKeyShortcut(handler: (e: KeyboardEvent) => void, options: KeyShortcutOptions) {
+    const { key, code, modifiers, enabled = true, fireInInputs = false, preventDefault = true } = options;
+
+    useEffect(() => {
+        if (!enabled) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key !== key && (!code || e.code !== code)) return;
+            if (!modifiersMatch(e, modifiers)) return;
+            if (!fireInInputs) {
+                const target = e.target as HTMLElement | null;
+                if (target) {
+                    const tag = target.tagName;
+                    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable) {
+                        return;
+                    }
+                }
+            }
+            if (preventDefault) e.preventDefault();
+            handler(e);
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [handler, key, code, modifiers, enabled, fireInInputs, preventDefault]);
+}

--- a/frontend/src/hooks/use-polling.ts
+++ b/frontend/src/hooks/use-polling.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { normalizeError } from "../utils";
 
 export interface PollResult<T> {
     data: T | null;
@@ -39,7 +40,7 @@ export function usePolling<T>(fetcher: () => Promise<T>, intervalMs: number): Po
             } catch (e) {
                 if (active) {
                     setData(null);
-                    setError(e instanceof Error ? e.message : "fetch failed");
+                    setError(normalizeError(e, "fetch failed"));
                 }
             }
             polling = false;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2296,6 +2296,154 @@ body {
     margin-top: 6px;
 }
 
+/* Motion player — playback controls + scrubber for the session replay */
+
+.history-player {
+    margin-top: 10px;
+}
+
+.history-player-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+}
+
+.history-player-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    padding: 0;
+    background: transparent;
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.history-player-btn:hover:not(:disabled) {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+}
+
+.history-player-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.history-player-btn span {
+    display: flex;
+}
+
+.history-player-btn svg {
+    width: 16px;
+    height: 16px;
+}
+
+.history-player-time {
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+    color: var(--text-dim);
+    min-width: 42px;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.history-player-scrubber {
+    flex: 1;
+    min-width: 0;
+    height: 18px;
+    appearance: none;
+    -webkit-appearance: none;
+    background: transparent;
+    cursor: pointer;
+    margin: 0;
+    --track: var(--border);
+    --played: 0%;
+    /* Dim the portion after the playhead to make progress visible on top
+       of the colored timeline. Composed: dim overlay (future half) over
+       the cleaning/recharge gradient. */
+    --dim: linear-gradient(
+        to right,
+        transparent 0,
+        transparent var(--played),
+        rgba(0, 0, 0, 0.45) var(--played),
+        rgba(0, 0, 0, 0.45) 100%
+    );
+}
+
+.history-player-scrubber::-webkit-slider-runnable-track {
+    height: 6px;
+    border-radius: 3px;
+    background: var(--dim), var(--track);
+    background-color: var(--border);
+}
+
+.history-player-scrubber::-moz-range-track {
+    height: 6px;
+    border-radius: 3px;
+    background: var(--dim), var(--track);
+    background-color: var(--border);
+    border: none;
+}
+
+.light .history-player-scrubber {
+    --dim: linear-gradient(
+        to right,
+        transparent 0,
+        transparent var(--played),
+        rgba(255, 255, 255, 0.55) var(--played),
+        rgba(255, 255, 255, 0.55) 100%
+    );
+}
+
+@media (prefers-color-scheme: light) {
+    .system-theme .history-player-scrubber {
+        --dim: linear-gradient(
+            to right,
+            transparent 0,
+            transparent var(--played),
+            rgba(255, 255, 255, 0.55) var(--played),
+            rgba(255, 255, 255, 0.55) 100%
+        );
+    }
+}
+
+.history-player-scrubber::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: rgba(52, 199, 89, 0.95);
+    border: 2px solid var(--surface);
+    cursor: grab;
+    margin-top: -4px; /* center 14px thumb over 6px track */
+}
+
+.history-player-scrubber::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: rgba(52, 199, 89, 0.95);
+    border: 2px solid var(--surface);
+    cursor: grab;
+}
+
+.history-player-scrubber:active::-webkit-slider-thumb {
+    cursor: grabbing;
+}
+
+.history-player-scrubber:active::-moz-range-thumb {
+    cursor: grabbing;
+}
+
 /* Schedule page */
 
 .schedule-page {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -210,7 +210,19 @@ export interface MapBounds {
 export interface MapRechargePoint {
     x: number;
     y: number;
+    // Session-relative timestamp when the robot returned to base to charge,
+    // derived from the last pose snapshot before collection paused.
+    ts: number;
+    // Session-relative timestamp when cleaning resumed after the charge —
+    // taken from the first pose snapshot written once collection restarted.
+    // Falls back to `ts` when the session ended before resuming.
+    endTs: number;
 }
+
+// Coverage cell with the session-relative timestamp (seconds) at which the
+// cell was first stamped. Used by the motion player to reveal coverage
+// progressively during playback.
+export type MapCoverageCell = [cx: number, cy: number, ts: number];
 
 export interface MapTransform {
     panX: number;
@@ -222,7 +234,7 @@ export interface MapData {
     session: MapSession | null;
     summary: MapSummary | null;
     path: MapPathPoint[];
-    coverage: [number, number][];
+    coverage: MapCoverageCell[];
     recharges: MapRechargePoint[];
     bounds: MapBounds | null;
     cellSize: number;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,15 @@
+// Small shared utilities. Keep dependency-free and side-effect-free so this
+// module can be imported from anywhere (components, hooks, plain modules)
+// without pulling in Preact.
+
+// Zero-pad a non-negative integer to the given width. Used for clock and
+// date formatting throughout the UI.
+export function pad2(n: number): string {
+    return n.toString().padStart(2, "0");
+}
+
+// Best-effort extraction of a human-readable message from a caught value.
+// Falls back to the provided default when the value isn't an Error instance.
+export function normalizeError(e: unknown, fallback = "Something went wrong"): string {
+    return e instanceof Error ? e.message : fallback;
+}

--- a/frontend/src/views/dashboard.tsx
+++ b/frontend/src/views/dashboard.tsx
@@ -28,6 +28,7 @@ import type { PollResult } from "../hooks/use-polling";
 import { usePolling } from "../hooks/use-polling";
 import type { ChargerData, ErrorData, FirmwareVersion, StateData, SystemData } from "../types";
 import type { UpdateInfo } from "../update";
+import { normalizeError } from "../utils";
 
 // -- Helpers --
 
@@ -158,7 +159,7 @@ export function DashboardView({ firmware, state, isManual, updateInfo, robotRead
                     clearTimeout(pendingTimer.current);
                     pendingTimer.current = null;
                 }
-                actionErrorStack.push(e instanceof Error ? e.message : "Action failed");
+                actionErrorStack.push(normalizeError(e, "Action failed"));
             });
         },
         [actionErrorStack],

--- a/frontend/src/views/history.tsx
+++ b/frontend/src/views/history.tsx
@@ -5,6 +5,7 @@ import { ErrorBannerStack, useErrorStack } from "../components/error-banner";
 import { Icon } from "../components/icon";
 import { useNavigate, usePath } from "../components/router";
 import type { HistoryFileInfo, MapData } from "../types";
+import { normalizeError } from "../utils";
 import { HistoryItemView } from "./history/item";
 import { HistoryListView } from "./history/list";
 
@@ -37,7 +38,7 @@ export function HistoryView() {
         api.getHistoryList()
             .then((fileList) => setFiles(sortByDateDesc(fileList)))
             .catch((e: unknown) => {
-                errorStack.push(e instanceof Error ? e.message : "Failed to load map data");
+                errorStack.push(normalizeError(e, "Failed to load map data"));
             })
             .finally(() => setLoading(false));
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -84,7 +85,7 @@ export function HistoryView() {
                 }
             })
             .catch((e: unknown) => {
-                errorStack.push(e instanceof Error ? e.message : "Failed to load session");
+                errorStack.push(normalizeError(e, "Failed to load session"));
             });
     }, [selectedName, errorStack]);
 
@@ -118,7 +119,7 @@ export function HistoryView() {
                     if (selectedName === file.name) navigate("/history");
                 })
                 .catch((e: unknown) => {
-                    errorStack.push(e instanceof Error ? e.message : "Failed to delete");
+                    errorStack.push(normalizeError(e, "Failed to delete"));
                 })
                 .finally(() => setDeleting(false));
         },
@@ -133,7 +134,7 @@ export function HistoryView() {
                 if (selectedName) navigate("/history");
             })
             .catch((e: unknown) => {
-                errorStack.push(e instanceof Error ? e.message : "Failed to delete");
+                errorStack.push(normalizeError(e, "Failed to delete"));
             })
             .finally(() => setDeleting(false));
     }, [selectedName, navigate, errorStack]);
@@ -142,7 +143,7 @@ export function HistoryView() {
         api.getHistoryList()
             .then((fileList) => setFiles(sortByDateDesc(fileList)))
             .catch((e: unknown) => {
-                errorStack.push(e instanceof Error ? e.message : "Failed to refresh list");
+                errorStack.push(normalizeError(e, "Failed to refresh list"));
             });
     }, [errorStack]);
 

--- a/frontend/src/views/history/helpers.ts
+++ b/frontend/src/views/history/helpers.ts
@@ -4,7 +4,8 @@ import clockSvg from "../../assets/icons/clock.svg?raw";
 import houseSvg from "../../assets/icons/house.svg?raw";
 import manualSvg from "../../assets/icons/manual.svg?raw";
 import spotSvg from "../../assets/icons/spot.svg?raw";
-import type { MapData, MapTransform } from "../../types";
+import type { MapData, MapPathPoint, MapTransform } from "../../types";
+import { pad2 } from "../../utils";
 
 const DEFAULT_TRANSFORM: MapTransform = { panX: 0, panY: 0, zoom: 1 };
 
@@ -15,13 +16,18 @@ export function formatDuration(secs: number): string {
     return s > 0 ? `${m}m ${s}s` : `${m}m`;
 }
 
+// Playback clock format — M:SS, or H:MM:SS past the hour mark.
+export function formatClock(secs: number): string {
+    const total = Math.max(0, Math.floor(secs));
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    return h > 0 ? `${h}:${pad2(m)}:${pad2(s)}` : `${m}:${pad2(s)}`;
+}
+
 export function formatDate(epoch: number): string {
     const d = new Date(epoch * 1000);
-    const mon = (d.getMonth() + 1).toString().padStart(2, "0");
-    const day = d.getDate().toString().padStart(2, "0");
-    const h = d.getHours().toString().padStart(2, "0");
-    const min = d.getMinutes().toString().padStart(2, "0");
-    return `${mon}/${day} ${h}:${min}`;
+    return `${pad2(d.getMonth() + 1)}/${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
 }
 
 export function modeInfo(mode: string): { label: string; icon: string } {
@@ -31,12 +37,70 @@ export function modeInfo(mode: string): { label: string; icon: string } {
     return { label: mode, icon: clockSvg };
 }
 
-// Canvas renderer for map visualization
-export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = false, tf?: MapTransform) {
+// Total session duration derived from the map data. Prefers the summary
+// value written by the firmware, falls back to the last pose timestamp.
+export function sessionDuration(map: MapData): number {
+    if (map.summary?.duration && map.summary.duration > 0) return map.summary.duration;
+    if (map.path.length > 0) return map.path[map.path.length - 1].ts;
+    return 0;
+}
+
+// Shortest-arc interpolation between two headings in degrees.
+function lerpAngleDeg(a: number, b: number, f: number): number {
+    const delta = ((b - a + 540) % 360) - 180;
+    return a + delta * f;
+}
+
+// Interpolate robot pose at a given session-relative timestamp. Returns
+// null when the path is empty. Uses linear interpolation for x/y and
+// shortest-arc interpolation for the heading so the sprite never snaps.
+export function interpolatePose(
+    path: MapPathPoint[],
+    ts: number,
+): { x: number; y: number; t: number; ts: number } | null {
+    if (path.length === 0) return null;
+    if (ts <= path[0].ts) return { ...path[0] };
+    const last = path[path.length - 1];
+    if (ts >= last.ts) return { ...last };
+
+    // Binary search for the segment containing ts
+    let lo = 0;
+    let hi = path.length - 1;
+    while (hi - lo > 1) {
+        const mid = (lo + hi) >> 1;
+        if (path[mid].ts <= ts) lo = mid;
+        else hi = mid;
+    }
+
+    const a = path[lo];
+    const b = path[hi];
+    const span = b.ts - a.ts;
+    const f = span > 0 ? (ts - a.ts) / span : 0;
+    return {
+        x: a.x + (b.x - a.x) * f,
+        y: a.y + (b.y - a.y) * f,
+        t: lerpAngleDeg(a.t, b.t, f),
+        ts,
+    };
+}
+
+// Canvas renderer for map visualization. When `currentTime` is provided the
+// renderer draws only the portion of the session up to that timestamp and
+// shows the interpolated robot pose as a directional sprite — used by the
+// motion player. Without `currentTime` the full static map is drawn.
+export function renderMap(
+    canvas: HTMLCanvasElement,
+    map: MapData,
+    recording = false,
+    tf?: MapTransform,
+    currentTime?: number,
+) {
     const ctx = canvas.getContext("2d");
     if (!ctx || !map.bounds) return;
 
     const { panX, panY, zoom } = tf ?? DEFAULT_TRANSFORM;
+    const playing = currentTime !== undefined;
+    const tNow = currentTime ?? Number.POSITIVE_INFINITY;
 
     const dpr = window.devicePixelRatio || 1;
     const displayW = canvas.clientWidth;
@@ -93,21 +157,40 @@ export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = f
         ctx.stroke();
     }
 
-    // Coverage cells
+    // Coverage cells — filtered by timestamp during playback
     const cellPx = map.cellSize * scale;
     ctx.fillStyle = isDark ? "rgba(52, 199, 89, 0.15)" : "rgba(22, 130, 50, 0.22)";
-    for (const [cx, cy] of map.coverage) {
+    for (const cell of map.coverage) {
+        const [cx, cy, ts] = cell;
+        if (ts > tNow) continue;
         const wx = cx * map.cellSize;
         const wy = cy * map.cellSize;
         ctx.fillRect(toX(wx) - cellPx / 2, toY(wy) - cellPx / 2, cellPx, cellPx);
     }
 
+    // Resolve the subset of path points to draw and the current robot pose
+    // when playing. During playback we cut the path at `tNow` and append
+    // an interpolated endpoint so the line keeps up with the robot sprite.
+    let pathEnd = map.path.length;
+    let liveHead: { x: number; y: number; t: number; ts: number } | null = null;
+    if (playing) {
+        pathEnd = 0;
+        while (pathEnd < map.path.length && map.path[pathEnd].ts <= tNow) pathEnd++;
+        liveHead = interpolatePose(map.path, tNow);
+    }
+
     // Path line
-    if (map.path.length > 1) {
+    const drawnPath: { x: number; y: number; ts: number }[] = [];
+    for (let i = 0; i < pathEnd; i++) drawnPath.push(map.path[i]);
+    if (playing && liveHead && (drawnPath.length === 0 || drawnPath[drawnPath.length - 1].ts !== liveHead.ts)) {
+        drawnPath.push(liveHead);
+    }
+
+    if (drawnPath.length > 1) {
         ctx.beginPath();
-        ctx.moveTo(toX(map.path[0].x), toY(map.path[0].y));
-        for (let i = 1; i < map.path.length; i++) {
-            ctx.lineTo(toX(map.path[i].x), toY(map.path[i].y));
+        ctx.moveTo(toX(drawnPath[0].x), toY(drawnPath[0].y));
+        for (let i = 1; i < drawnPath.length; i++) {
+            ctx.lineTo(toX(drawnPath[i].x), toY(drawnPath[i].y));
         }
         ctx.strokeStyle = isDark ? "rgba(249, 235, 178, 0.6)" : "rgba(180, 140, 40, 0.5)";
         ctx.lineWidth = 2;
@@ -125,8 +208,10 @@ export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = f
         ctx.fill();
     }
 
-    // End point - open ring with glow when recording, solid dot when finished
-    if (map.path.length > 1) {
+    // End point / animated robot sprite
+    if (playing && liveHead) {
+        drawRobotSprite(ctx, toX(liveHead.x), toY(liveHead.y), liveHead.t);
+    } else if (map.path.length > 1) {
         const end = map.path[map.path.length - 1];
         const ex = toX(end.x);
         const ey = toY(end.y);
@@ -148,8 +233,9 @@ export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = f
         }
     }
 
-    // Recharge points (bolt icon with glow)
+    // Recharge points (bolt icon with glow) — hidden until reached during playback
     for (const rp of map.recharges) {
+        if (rp.ts > tNow) continue;
         const rx = toX(rp.x);
         const ry = toY(rp.y);
         const s = 10;
@@ -175,4 +261,43 @@ export function renderMap(canvas: HTMLCanvasElement, map: MapData, recording = f
         ctx.lineWidth = 1.5;
         ctx.stroke();
     }
+}
+
+// Draws the animated robot sprite: a filled circle with a small nose pointing
+// in the heading direction. Theta is in degrees, 0 = +X axis (canvas right),
+// increasing counter-clockwise in world coordinates, so we flip the sign when
+// applying it to screen coordinates (Y axis is inverted by toY).
+function drawRobotSprite(ctx: CanvasRenderingContext2D, x: number, y: number, thetaDeg: number) {
+    const radius = 7;
+    const screenAngle = -(thetaDeg * Math.PI) / 180;
+
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(screenAngle);
+
+    // Heading wedge behind the body so it reads as a direction arrow
+    ctx.beginPath();
+    ctx.moveTo(radius + 5, 0);
+    ctx.lineTo(radius * 0.6, -radius * 0.7);
+    ctx.lineTo(radius * 0.6, radius * 0.7);
+    ctx.closePath();
+    ctx.fillStyle = "rgba(52, 199, 89, 0.95)";
+    ctx.fill();
+
+    // Body
+    ctx.shadowColor = "rgba(52, 199, 89, 0.6)";
+    ctx.shadowBlur = 10;
+    ctx.beginPath();
+    ctx.arc(0, 0, radius, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(52, 199, 89, 0.95)";
+    ctx.fill();
+    ctx.shadowBlur = 0;
+
+    // Inner dot for contrast
+    ctx.beginPath();
+    ctx.arc(0, 0, radius * 0.35, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
+    ctx.fill();
+
+    ctx.restore();
 }

--- a/frontend/src/views/history/item.tsx
+++ b/frontend/src/views/history/item.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import boltSvg from "../../assets/icons/bolt.svg?raw";
 import { Icon } from "../../components/icon";
 import { useMapGestures } from "../../hooks/use-map-gestures";
 import type { HistoryFileInfo, MapData } from "../../types";
 import { formatDuration, renderMap } from "./helpers";
+import { MotionPlayer } from "./motion-player";
 
 interface HistoryItemViewProps {
     file: HistoryFileInfo;
@@ -16,22 +17,37 @@ export function HistoryItemView({ file, map, mapEmpty, recording }: HistoryItemV
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const transform = useMapGestures(canvasRef);
 
-    // Render canvas when map data or transform changes
+    // Expose the live canvas element so MotionPlayer can drive the renderer
+    // without duplicating gesture handling or the ref plumbing.
+    const [canvasEl, setCanvasEl] = useState<HTMLCanvasElement | null>(null);
     useEffect(() => {
+        setCanvasEl(canvasRef.current);
+    }, [map]);
+
+    // Motion playback is only available for finished sessions. While
+    // recording we fall back to the live static render (with its pulsing
+    // end marker) so the existing behaviour is unchanged.
+    const showPlayer = !recording && map !== null && map.path.length > 0;
+
+    // When the player is visible it owns all canvas draws. Otherwise we
+    // render the static map here so recording sessions and loading states
+    // keep working exactly as before.
+    useEffect(() => {
+        if (showPlayer) return;
         if (map && canvasRef.current) {
             renderMap(canvasRef.current, map, recording, transform);
         }
-    }, [map, recording, transform]);
+    }, [map, recording, transform, showPlayer]);
 
-    // Re-render on resize
     useEffect(() => {
+        if (showPlayer) return;
         if (!map) return;
         const handleResize = () => {
             if (map && canvasRef.current) renderMap(canvasRef.current, map, recording, transform);
         };
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
-    }, [map, recording, transform]);
+    }, [map, recording, transform, showPlayer]);
 
     // Prefer list metadata summary (available immediately), fall back to
     // the summary parsed from the full JSONL data (available after fetch)
@@ -77,6 +93,9 @@ export function HistoryItemView({ file, map, mapEmpty, recording }: HistoryItemV
                 <canvas ref={canvasRef} class="history-canvas" style={map ? undefined : { display: "none" }} />
             </div>
 
+            {/* Motion player (finished sessions only) */}
+            {showPlayer && map && <MotionPlayer canvas={canvasEl} map={map} transform={transform} />}
+
             {/* Legend */}
             {map && (
                 <div class="history-legend">
@@ -102,6 +121,11 @@ export function HistoryItemView({ file, map, mapEmpty, recording }: HistoryItemV
             )}
             {map && (
                 <div class="history-map-hint">Pinch or scroll to zoom, drag to pan, double-tap to zoom in or reset</div>
+            )}
+            {showPlayer && (
+                <div class="history-map-hint">
+                    Space to play or pause, arrow keys to seek, hold shift for a larger jump
+                </div>
             )}
         </>
     );

--- a/frontend/src/views/history/list.tsx
+++ b/frontend/src/views/history/list.tsx
@@ -7,6 +7,7 @@ import trashSvg from "../../assets/icons/trash.svg?raw";
 import { ConfirmDialog } from "../../components/confirm-dialog";
 import { Icon } from "../../components/icon";
 import type { HistoryFileInfo, MapSession, MapSummary } from "../../types";
+import { normalizeError } from "../../utils";
 import { formatDate, formatDuration, modeInfo } from "./helpers";
 
 // Session card component
@@ -163,7 +164,7 @@ export function HistoryListView({
                 })
                 .catch((e: unknown) => {
                     setImportStatus("error");
-                    onError(e instanceof Error ? e.message : "Import failed");
+                    onError(normalizeError(e, "Import failed"));
                     setTimeout(() => setImportStatus("idle"), 2000);
                 })
                 .finally(() => {

--- a/frontend/src/views/history/motion-player.tsx
+++ b/frontend/src/views/history/motion-player.tsx
@@ -1,0 +1,235 @@
+// Motion player — replays a finished cleaning session as a smoothly animated
+// robot on the map. Drives the time-aware variant of renderMap via
+// requestAnimationFrame and exposes play/pause, restart, and a scrubber.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import pauseSvg from "../../assets/icons/pause.svg?raw";
+import playSvg from "../../assets/icons/play.svg?raw";
+import restartSvg from "../../assets/icons/restart.svg?raw";
+import { Icon } from "../../components/icon";
+import { useKeyShortcut } from "../../hooks/use-key-shortcut";
+import type { MapData, MapTransform } from "../../types";
+import { formatClock, renderMap, sessionDuration } from "./helpers";
+
+interface MotionPlayerProps {
+    canvas: HTMLCanvasElement | null;
+    map: MapData;
+    transform: MapTransform;
+    // Seconds of session time played per real second. 1x replays in real time,
+    // higher values speed the playback up proportionally.
+    speed?: number;
+}
+
+export function MotionPlayer({ canvas, map, transform, speed = 8 }: MotionPlayerProps) {
+    const duration = sessionDuration(map);
+    const [playing, setPlaying] = useState(false);
+    // Start at the end of the timeline so a freshly opened session shows the
+    // completed map. Pressing play rewinds to 0 and animates forward.
+    const [currentTime, setCurrentTime] = useState(duration);
+
+    // Refs used inside the rAF loop so we don't recreate the loop on every
+    // state change. The loop reads the latest time via ref.
+    const timeRef = useRef(duration);
+    const lastFrameRef = useRef(0);
+    const rafRef = useRef<number | null>(null);
+
+    // Keep ref in sync so rAF reads live value.
+    useEffect(() => {
+        timeRef.current = currentTime;
+    }, [currentTime]);
+
+    // Re-render canvas whenever the time, transform, or map changes. This
+    // runs on every animation frame tick via the setCurrentTime update.
+    useEffect(() => {
+        if (!canvas || !map) return;
+        renderMap(canvas, map, false, transform, currentTime);
+    }, [canvas, map, transform, currentTime]);
+
+    // Re-render on resize — canvas backing store gets invalidated.
+    useEffect(() => {
+        if (!canvas) return;
+        const onResize = () => {
+            renderMap(canvas, map, false, transform, timeRef.current);
+        };
+        window.addEventListener("resize", onResize);
+        return () => window.removeEventListener("resize", onResize);
+    }, [canvas, map, transform]);
+
+    // Reset to the completed map whenever the session switches. The scrubber
+    // anchors at `duration` so the user sees the full session at rest.
+    useEffect(() => {
+        setPlaying(false);
+        setCurrentTime(duration);
+    }, [map, duration]);
+
+    // Animation loop. Advances session time based on wall-clock delta * speed.
+    useEffect(() => {
+        if (!playing) {
+            if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+            return;
+        }
+        lastFrameRef.current = performance.now();
+        const tick = (now: number) => {
+            const dt = (now - lastFrameRef.current) / 1000;
+            lastFrameRef.current = now;
+            const next = timeRef.current + dt * speed;
+            if (next >= duration) {
+                setCurrentTime(duration);
+                setPlaying(false);
+                return;
+            }
+            setCurrentTime(next);
+            rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+        return () => {
+            if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        };
+    }, [playing, duration, speed]);
+
+    const handleTogglePlay = useCallback(() => {
+        setPlaying((prev) => {
+            if (prev) return false;
+            // Pressing play from the resting "full map" state (or after a
+            // previous playback finished) rewinds to the beginning so the
+            // user sees a proper replay.
+            if (timeRef.current >= duration) setCurrentTime(0);
+            return true;
+        });
+    }, [duration]);
+
+    const handleRestart = useCallback(() => {
+        // Cancel any in-flight rAF tick, jump the playhead to 0, and pause
+        // so the user can resume playback manually when ready.
+        if (rafRef.current !== null) {
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = null;
+        }
+        timeRef.current = 0;
+        setCurrentTime(0);
+        setPlaying(false);
+    }, []);
+
+    // Seek by a constant delta (seconds), clamped to the session range.
+    // Used by the arrow-key shortcuts — a small step for single presses, a
+    // larger jump when Shift is held. Pauses playback so the rAF loop
+    // doesn't fight the seek by overwriting the time on the next tick.
+    const seekBy = useCallback(
+        (delta: number) => {
+            setPlaying(false);
+            const next = Math.max(0, Math.min(duration, timeRef.current + delta));
+            timeRef.current = next;
+            setCurrentTime(next);
+        },
+        [duration],
+    );
+
+    const seekStep = duration * 0.01;
+    const seekJump = duration * 0.05;
+
+    // Keyboard shortcuts — space toggles play/pause, left/right seek by one
+    // small step, shift+left/right jump further.
+    useKeyShortcut(handleTogglePlay, { key: " ", code: "Space" });
+    useKeyShortcut(() => seekBy(-seekStep), { key: "ArrowLeft" });
+    useKeyShortcut(() => seekBy(seekStep), { key: "ArrowRight" });
+    useKeyShortcut(() => seekBy(-seekJump), { key: "ArrowLeft", modifiers: { shift: true } });
+    useKeyShortcut(() => seekBy(seekJump), { key: "ArrowRight", modifiers: { shift: true } });
+
+    const handleScrub = useCallback(
+        (e: Event) => {
+            const input = e.currentTarget as HTMLInputElement;
+            const v = Number(input.value);
+            if (!Number.isFinite(v)) return;
+            setCurrentTime(Math.max(0, Math.min(duration, v)));
+        },
+        [duration],
+    );
+
+    const handleScrubStart = useCallback(() => {
+        // Pause while the user drags so the scrubber doesn't fight the loop.
+        setPlaying(false);
+    }, []);
+
+    // Background gradient for the scrubber track: green for active cleaning,
+    // yellow for recharge windows, and a darker "unplayed" overlay past the
+    // current playhead. Composited as two gradients — the bottom layer is
+    // the full cleaning/recharge timeline, the top layer dims the future.
+    const { trackLayers, playedPercent } = useMemo(() => {
+        if (duration <= 0) return { trackLayers: "", playedPercent: 0 };
+        const CLEAN = "rgba(52, 199, 89, 0.75)";
+        const CHARGE = "rgba(255, 204, 0, 0.85)";
+
+        // Sort and clamp recharge windows to [0, duration]
+        const windows = map.recharges
+            .map((r) => [Math.max(0, Math.min(duration, r.ts)), Math.max(0, Math.min(duration, r.endTs))] as const)
+            .filter(([a, b]) => b > a)
+            .sort((a, b) => a[0] - b[0]);
+
+        // Build hard-edged gradient stops walking forward through time.
+        const stops: string[] = [];
+        let cursor = 0;
+        const toPct = (t: number) => `${((t / duration) * 100).toFixed(3)}%`;
+        const pushSegment = (color: string, from: number, to: number) => {
+            stops.push(`${color} ${toPct(from)}`);
+            stops.push(`${color} ${toPct(to)}`);
+        };
+        for (const [from, to] of windows) {
+            if (from > cursor) pushSegment(CLEAN, cursor, from);
+            pushSegment(CHARGE, Math.max(cursor, from), to);
+            cursor = to;
+        }
+        if (cursor < duration) pushSegment(CLEAN, cursor, duration);
+
+        const timeline = `linear-gradient(to right, ${stops.join(", ")})`;
+        const pct = (Math.min(duration, Math.max(0, currentTime)) / duration) * 100;
+        return { trackLayers: timeline, playedPercent: pct };
+    }, [duration, map.recharges, currentTime]);
+
+    // Render a disabled shell when there isn't enough data to animate, so the
+    // layout stays stable while the session loads.
+    if (duration <= 0 || map.path.length === 0) {
+        return null;
+    }
+
+    return (
+        <div class="history-player">
+            <div class="history-player-controls">
+                <button
+                    type="button"
+                    class="history-player-btn"
+                    onClick={handleTogglePlay}
+                    aria-label={playing ? "Pause" : "Play"}
+                >
+                    <Icon svg={playing ? pauseSvg : playSvg} />
+                </button>
+                <button type="button" class="history-player-btn" onClick={handleRestart} aria-label="Restart">
+                    <Icon svg={restartSvg} />
+                </button>
+                <span class="history-player-time" title="Elapsed time">
+                    {formatClock(currentTime)}
+                </span>
+                <input
+                    type="range"
+                    class="history-player-scrubber"
+                    min={0}
+                    max={duration}
+                    step={0.1}
+                    value={currentTime}
+                    onInput={handleScrub}
+                    onMouseDown={handleScrubStart}
+                    onTouchStart={handleScrubStart}
+                    aria-label="Seek"
+                    style={{
+                        "--track": trackLayers,
+                        "--played": `${playedPercent}%`,
+                    }}
+                />
+                <span class="history-player-time" title="Total time">
+                    {formatClock(duration)}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/views/logs/helpers.ts
+++ b/frontend/src/views/logs/helpers.ts
@@ -1,5 +1,7 @@
 // Shared helpers for logs views
 
+import { pad2 } from "../../utils";
+
 export function formatBytes(bytes: number): string {
     if (bytes < 1024) return `${bytes} B`;
     const kb = bytes / 1024;
@@ -14,11 +16,7 @@ export function filenameToDate(name: string): string {
     if (match) {
         const epoch = parseInt(match[1], 10);
         const d = new Date(epoch * 1000);
-        const mon = (d.getMonth() + 1).toString().padStart(2, "0");
-        const day = d.getDate().toString().padStart(2, "0");
-        const h = d.getHours().toString().padStart(2, "0");
-        const m = d.getMinutes().toString().padStart(2, "0");
-        return `${mon}/${day} ${h}:${m}`;
+        return `${pad2(d.getMonth() + 1)}/${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
     }
     return name;
 }
@@ -52,10 +50,7 @@ export function typeBadge(type: string): TypeBadge {
 
 export function formatTimestamp(ts: number): string {
     const d = new Date(ts * 1000);
-    const h = d.getHours().toString().padStart(2, "0");
-    const m = d.getMinutes().toString().padStart(2, "0");
-    const s = d.getSeconds().toString().padStart(2, "0");
-    return `${h}:${m}:${s}`;
+    return `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
 }
 
 function formatResp(raw: string): string {

--- a/frontend/src/views/logs/item.tsx
+++ b/frontend/src/views/logs/item.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import { api } from "../../api";
 import databaseSvg from "../../assets/icons/database.svg?raw";
 import { Icon } from "../../components/icon";
+import { normalizeError } from "../../utils";
 import type { LogEntry } from "./helpers";
 import { DETAIL_KEY, formatTimestamp, parseLogLine, typeBadge } from "./helpers";
 
@@ -96,7 +97,7 @@ export function LogsItemView({ filename, onError }: LogsItemViewProps) {
                 setLoading(false);
             })
             .catch((e: unknown) => {
-                onError(e instanceof Error ? e.message : "Failed to load log");
+                onError(normalizeError(e, "Failed to load log"));
                 setLoading(false);
             });
     }, [filename, onError]);

--- a/frontend/src/views/logs/list.tsx
+++ b/frontend/src/views/logs/list.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from "../../components/confirm-dialog";
 import { Icon } from "../../components/icon";
 import { useNavigate } from "../../components/router";
 import type { LogFileInfo } from "../../types";
+import { normalizeError } from "../../utils";
 import { filenameToDate, formatBytes } from "./helpers";
 
 interface LogsListViewProps {
@@ -35,7 +36,7 @@ export function LogsListView({ onError }: LogsListViewProps) {
                 setLoading(false);
             })
             .catch((e: unknown) => {
-                onError(e instanceof Error ? e.message : "Failed to load logs");
+                onError(normalizeError(e, "Failed to load logs"));
                 setLoading(false);
             });
     }, [onError]);
@@ -53,7 +54,7 @@ export function LogsListView({ onError }: LogsListViewProps) {
             api.deleteAllLogs()
                 .then(() => setFiles([]))
                 .catch((e: unknown) => {
-                    onError(e instanceof Error ? e.message : "Failed to delete logs");
+                    onError(normalizeError(e, "Failed to delete logs"));
                 })
                 .finally(() => setDeletingAll(false));
         } else {
@@ -64,7 +65,7 @@ export function LogsListView({ onError }: LogsListViewProps) {
                     setFiles((prev) => prev.filter((f) => f.name !== name));
                 })
                 .catch((e: unknown) => {
-                    onError(e instanceof Error ? e.message : "Failed to delete log");
+                    onError(normalizeError(e, "Failed to delete log"));
                 })
                 .finally(() => setDeleting(null));
         }

--- a/frontend/src/views/schedule.tsx
+++ b/frontend/src/views/schedule.tsx
@@ -8,6 +8,7 @@ import { Icon } from "../components/icon";
 import { useDirtyGuard } from "../hooks/use-dirty-guard";
 import { useFetch } from "../hooks/use-fetch";
 import type { SettingsData, SystemData } from "../types";
+import { normalizeError, pad2 } from "../utils";
 import { findCurrentTzAbbrev, findPresetLabel } from "./settings/helpers";
 
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -65,7 +66,7 @@ function buildSchedulePatch(days: DayState[], server: DayState[]): Partial<Setti
 }
 
 function fmtTime(h: number, m: number): string {
-    return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+    return `${pad2(h)}:${pad2(m)}`;
 }
 
 function parseTime(value: string): { hour: number; minute: number } | null {
@@ -230,7 +231,7 @@ export function ScheduleView() {
                 setEnabled(res.scheduleEnabled);
             })
             .catch((e: unknown) => {
-                errorStack.push(e instanceof Error ? e.message : "Failed to save schedule");
+                errorStack.push(normalizeError(e, "Failed to save schedule"));
             })
             .finally(() => setSaving(false));
     }, [days, drafts, enabled, errorStack]);

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -24,6 +24,7 @@ import { useNavigate } from "../components/router";
 import { useDirtyGuard } from "../hooks/use-dirty-guard";
 import { usePolling } from "../hooks/use-polling";
 import type { FirmwareVersion, SystemData, UserSettingsData } from "../types";
+import { normalizeError } from "../utils";
 import {
     BRUSH_PRESETS,
     NAV_MODE_PRESETS,
@@ -149,7 +150,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
             const serialValue = value ? "ON" : "OFF";
             api.setUserSetting(robotSettingKeys[field], serialValue)
                 .catch((e: unknown) => {
-                    errorStack.push(e instanceof Error ? e.message : "Failed to update robot settings");
+                    errorStack.push(normalizeError(e, "Failed to update robot settings"));
                     if (userSettingsPoll.data) setRobotSettings(userSettingsPoll.data);
                 })
                 .finally(() => setSavingRobotSettings(false));
@@ -171,7 +172,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                 setTimeout(() => setNotifTestResult(null), 2000);
             })
             .catch((e: unknown) => {
-                setNotifTestResult(e instanceof Error ? e.message : "Failed");
+                setNotifTestResult(normalizeError(e, "Failed"));
                 setTimeout(() => setNotifTestResult(null), 3000);
             })
             .finally(() => setTestingNotif(false));
@@ -229,7 +230,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                 if (robotRestartTimeout.current) clearTimeout(robotRestartTimeout.current);
                 robotRestartTimeout.current = null;
                 setRobotRestarting(false);
-                errorStack.push(e instanceof Error ? e.message : "Failed to restart robot");
+                errorStack.push(normalizeError(e, "Failed to restart robot"));
             });
     }, [errorStack]);
 
@@ -250,7 +251,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         setClearingErrors(true);
         api.clearErrors()
             .catch((e: unknown) => {
-                errorStack.push(e instanceof Error ? e.message : "Failed to clear errors");
+                errorStack.push(normalizeError(e, "Failed to clear errors"));
             })
             .finally(() => setClearingErrors(false));
     }, [errorStack]);
@@ -273,7 +274,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     setShowRestartConfirm(false);
                     startRebootFlow();
                 } else {
-                    errorStack.push(e instanceof Error ? e.message : "Failed to restart");
+                    errorStack.push(normalizeError(e, "Failed to restart"));
                     setShowRestartConfirm(false);
                 }
             })
@@ -292,7 +293,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     setShowFormatConfirm(false);
                     startRebootFlow();
                 } else {
-                    errorStack.push(e instanceof Error ? e.message : "Failed to format storage");
+                    errorStack.push(normalizeError(e, "Failed to format storage"));
                     setShowFormatConfirm(false);
                 }
             })
@@ -311,7 +312,7 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                     setShowResetConfirm(false);
                     startRebootFlow();
                 } else {
-                    errorStack.push(e instanceof Error ? e.message : "Failed to factory reset");
+                    errorStack.push(normalizeError(e, "Failed to factory reset"));
                     setShowResetConfirm(false);
                 }
             })

--- a/frontend/src/views/settings/use-firmware-upload.ts
+++ b/frontend/src/views/settings/use-firmware-upload.ts
@@ -3,6 +3,7 @@ import { api } from "../../api";
 import type { ErrorStackHandle } from "../../components/error-banner";
 import { md5 } from "../../md5";
 import { sha256 } from "../../sha256";
+import { normalizeError } from "../../utils";
 
 type UploadStatus = "idle" | "hashing" | "uploading" | "done";
 
@@ -204,7 +205,7 @@ export function useFirmwareUpload(
         } catch (e: unknown) {
             stopProgressAnim();
             setStatus("idle");
-            errorStack.push(e instanceof Error ? e.message : "Firmware upload failed");
+            errorStack.push(normalizeError(e, "Firmware upload failed"));
         }
     }, [file, errorStack, startRebootFlow, startProgressAnim, stopProgressAnim, onUploadProgress]);
 

--- a/frontend/src/views/settings/use-settings-form.ts
+++ b/frontend/src/views/settings/use-settings-form.ts
@@ -3,6 +3,7 @@ import { api } from "../../api";
 import type { ErrorStackHandle } from "../../components/error-banner";
 import { useFetch } from "../../hooks/use-fetch";
 import type { SettingsData } from "../../types";
+import { normalizeError } from "../../utils";
 import { DEFAULT_SERVER } from "./constants";
 
 export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: () => void) {
@@ -185,7 +186,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
                     setShowSaveConfirm(false);
                     startRebootFlow();
                 } else {
-                    errorStack.push(e instanceof Error ? e.message : "Failed to save settings");
+                    errorStack.push(normalizeError(e, "Failed to save settings"));
                     setShowSaveConfirm(false);
                 }
             })


### PR DESCRIPTION
## Summary

- Motion player on the history detail view replays finished sessions as a smoothly animated robot sprite, with play/pause, restart, and a scrubber
- Time-aware renderMap reveals path, coverage, and recharge markers progressively with interpolated robot pose
- Scrubber shows cleaning (green) vs recharge (yellow) segments, derived from gaps in the pose timestamps
- Keyboard shortcuts: space to play/pause, arrow keys to seek, shift+arrow for a larger jump
- Extract `useKeyShortcut` hook and shared `pad2` / `normalizeError` utilities

Closes #86