### PR TITLE
fix: openneato-flash not working on Mojave

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,24 @@ builds:
     env:
       - >-
         {{- if eq .Os "darwin" }}CGO_ENABLED=1{{- else }}CGO_ENABLED=0{{- end }}
+      # On darwin/amd64, target macOS 10.13 so the linker doesn't emit newer
+      # load commands (e.g. LC_DYLD_CHAINED_FIXUPS, LC_ATOM_INFO) that older
+      # dyld versions can't parse. arm64 darwin requires macOS 11+ minimum.
+      - >-
+        {{- if eq .Os "darwin" }}
+          {{- if eq .Arch "amd64" }}MACOSX_DEPLOYMENT_TARGET=10.13
+          {{- else }}MACOSX_DEPLOYMENT_TARGET=11.0{{- end }}
+        {{- end }}
+      - >-
+        {{- if eq .Os "darwin" }}
+          {{- if eq .Arch "amd64" }}CGO_CFLAGS=-mmacosx-version-min=10.13
+          {{- else }}CGO_CFLAGS=-mmacosx-version-min=11.0{{- end }}
+        {{- end }}
+      - >-
+        {{- if eq .Os "darwin" }}
+          {{- if eq .Arch "amd64" }}CGO_LDFLAGS=-mmacosx-version-min=10.13 -Wl,-no_fixup_chains
+          {{- else }}CGO_LDFLAGS=-mmacosx-version-min=11.0{{- end }}
+        {{- end }}
     goos:
       - linux
       - darwin


### PR DESCRIPTION
## Summary

- Set `MACOSX_DEPLOYMENT_TARGET=10.13` and `-Wl,-no_fixup_chains` for darwin/amd64 builds so the linker emits `LC_VERSION_MIN_MACOSX` and `LC_DYLD_INFO_ONLY` instead of newer load commands (`LC_BUILD_VERSION`, `LC_DYLD_CHAINED_FIXUPS`, `LC_ATOM_INFO`) that dyld on Mojave and earlier cannot parse
- Pin darwin/arm64 to `MACOSX_DEPLOYMENT_TARGET=11.0` (lowest version supporting Apple Silicon)

Fixes #101