### PR TITLE
feat: fallback WiFi access point for browser-based provisioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,9 @@ CSS frameworks, routing, or HTTP wrapper libraries.
 
 - 4-space indent, double quotes, semicolons, 120-col (Biome)
 - Named `interface`/`type` only, never inline object type literals
+- Reuse existing CSS utilities and component classes before adding new ones.
+  When two rules share a body, consolidate via a shared selector list, a
+  shared class, or a CSS custom property.
 
 ## Hardware
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,10 +15,12 @@ Everything you need to set up, configure, and troubleshoot OpenNeato.
     - [Command Reference](#command-reference)
     - [Troubleshooting Flash Issues](#troubleshooting-flash-issues)
 - [First-Time WiFi Setup](#first-time-wifi-setup)
-    - [Serial Monitor](#serial-monitor)
+    - [Option A: Fallback Access Point (no serial cable)](#option-a-fallback-access-point-no-serial-cable)
+    - [Option B: Serial Monitor](#option-b-serial-monitor)
     - [WiFi Configuration Menu](#wifi-configuration-menu)
     - [Verifying the Connection](#verifying-the-connection)
     - [Quick Commands](#quick-commands)
+    - [Reconfiguring WiFi Later](#reconfiguring-wifi-later)
 - [Troubleshooting](#troubleshooting)
     - [Enabling Logging](#enabling-logging)
     - [Collecting Logs](#collecting-logs)
@@ -232,23 +234,48 @@ Windows, close any other serial monitor that might have the port open.
 
 ## First-Time WiFi Setup
 
-After flashing, the tool opens a serial monitor where you'll configure WiFi.
+After flashing, the device has no saved WiFi credentials and won't be on your network yet.
+You have two ways to provision it: a browser via the fallback access point (no serial cable
+needed), or the serial menu that the flash tool opens for you.
 
-### Serial Monitor
+### Option A: Fallback Access Point (no serial cable)
+
+When the device has no saved credentials, it broadcasts an open WiFi network so you can
+configure it from any phone or laptop browser. This works even after you've unplugged the
+USB cable and tucked the ESP32 inside the robot.
+
+1. From your phone or laptop, connect to the WiFi network named **`neato-ap`** (or
+   `<hostname>-ap` if you've changed the hostname). It's an open network , no password.
+2. Open a browser and go to `http://192.168.4.1`. You'll land on the OpenNeato dashboard.
+3. Open **Settings -> WiFi**, tap **Scan**, pick your home network from the dropdown, and
+   enter the password.
+4. After confirming, the device joins your home network and reboots. The `neato-ap` network
+   disappears at that point , reconnect your phone/laptop to your home WiFi to keep using
+   the web UI at `http://neato.local` (or the IP shown on the dashboard).
+
+> [!NOTE]
+> The fallback AP is unencrypted because there's no way to display a password to a user
+> who hasn't set one up yet. It only runs while the device has no saved credentials or
+> cannot reach your home network. Once connected, it shuts down automatically.
+
+### Option B: Serial Monitor
 
 The serial monitor connects at 115,200 baud and shows the ESP32's boot output. You'll see
-the boot banner:
+the boot banner. With no credentials saved, the fallback AP comes up automatically and the
+banner reflects that:
 
 ```
 ========================================
   OpenNeato v0.1
 ========================================
-  WiFi: not configured
+  WiFi: AP mode, connect to neato-ap and open http://192.168.4.1
   Press 'm' for menu, 's' for status
 ========================================
 ```
 
-If WiFi is not configured, the configuration menu appears automatically.
+You can finish provisioning either by joining `neato-ap` from a browser (Option A above) or
+by pressing `m` to open the WiFi configuration menu over serial , both end up in the same
+place.
 
 ### WiFi Configuration Menu
 
@@ -308,6 +335,21 @@ Once connected, you can type single-key commands in the serial monitor at any ti
 |-----|-----------------------------------------|
 | `m` | Open WiFi configuration menu            |
 | `s` | Print WiFi status (SSID, IP, MAC, RSSI) |
+
+### Reconfiguring WiFi Later
+
+Once the device is on your home network you can change networks from the web UI directly:
+**Settings -> WiFi -> Scan**, pick a new network, enter the password.
+
+If your home network goes down or you've moved house, the bridge falls back to the
+`<hostname>-ap` access point automatically so you can re-provision it from a browser without
+opening up the robot. This behavior is controlled by the **Fallback AP on disconnect** toggle
+in the WiFi section , it's on by default. If you turn it off, recovery from a broken WiFi
+config requires the serial menu.
+
+To wipe credentials entirely and force the device back into first-time setup mode (always-on
+AP, no auto-reconnect), use **Settings -> WiFi -> Forget current network**. The device will
+broadcast `<hostname>-ap` until you provision a new network.
 
 ---
 

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -110,6 +110,18 @@ enum CommandStatus {
 // NVS keys — WiFi
 #define NVS_KEY_WIFI_SSID "wifi_ssid"
 #define NVS_KEY_WIFI_PASS "wifi_pass"
+#define NVS_KEY_AP_FALLBACK "ap_fallback"
+
+// Fallback Access Point (provisioning AP)
+// SSID is derived from hostname: "<hostname>-ap". Network is open (no password).
+// AP is automatic: always on when no STA credentials saved; on/off based on
+// apFallbackOnDisconnect setting when STA connection drops.
+#define AP_SSID_SUFFIX "-ap"
+#define AP_DEFAULT_IP IPAddress(192, 168, 4, 1)
+#define AP_GATEWAY IPAddress(192, 168, 4, 1)
+#define AP_SUBNET IPAddress(255, 255, 255, 0)
+#define AP_CHANNEL 1
+#define AP_MAX_CONNECTIONS 4
 
 // NVS keys — Time/NTP
 #define NVS_KEY_TIMEZONE "tz"

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -30,7 +30,7 @@ ManualCleanManager manualClean(neatoSerial);
 NotificationManager notifMgr(neatoSerial, settingsManager, dataLogger);
 CleaningHistory cleaningHistory(neatoSerial, dataLogger, systemManager);
 WebServer webServer(server, neatoSerial, dataLogger, systemManager, firmwareManager, settingsManager, manualClean,
-                    notifMgr, cleaningHistory);
+                    notifMgr, cleaningHistory, wifiManager);
 
 // Tracks whether web server has been started (may be deferred if WiFi was slow at boot)
 bool webServerStarted = false;
@@ -54,7 +54,11 @@ void setup() {
     settingsManager.onTzChange([&](const String& tz) { systemManager.applyTimezone(tz); });
     settingsManager.onTxPowerChange([&](int quarterDbm) { wifiManager.setTxPower(quarterDbm); });
     settingsManager.onRebootRequired([&] { systemManager.restart(); });
+    settingsManager.onApFallbackChange([&](bool enabled) { wifiManager.setApFallbackOnDisconnect(enabled); });
     settingsManager.begin();
+
+    // Push initial AP fallback policy into WiFiManager before begin()
+    wifiManager.setApFallbackOnDisconnect(settingsManager.get().apFallbackOnDisconnect);
 
     // Apply manual clean settings from NVS (stall threshold, motor speeds)
     const auto& s = settingsManager.get();
@@ -115,19 +119,24 @@ void setup() {
         dataLogger.logNtp("sync_ok", {{"epoch", String(static_cast<long>(t)), FIELD_INT}});
     });
 
-    // Initialize web server and OTA if WiFi is already connected.
-    // If WiFi is slow (e.g. DHCP timeout after OTA), the web server will be
-    // started later in loop() once WiFi comes up — see deferred start below.
-    if (wifiManager.isConnected()) {
+    // Initialize web server and OTA if any network interface is up , STA
+    // (normal operation) or fallback AP (provisioning). Without either, the
+    // server has no socket to bind to. The deferred path in loop() picks up
+    // any late-arriving STA association.
+    if (wifiManager.isConnected() || wifiManager.isApActive()) {
         LOG("BOOT", "Initializing web server...");
         webServer.begin();
         LOG("BOOT", "Starting HTTP server...");
         server.begin();
         webServerStarted = true;
 
-        // Mark firmware as valid — cancels auto-rollback on next reboot
-        esp_ota_mark_app_valid_cancel_rollback();
-        LOG("BOOT", "Firmware marked valid");
+        // Mark firmware as valid , cancels auto-rollback on next reboot.
+        // Only cancel rollback once we have STA connectivity, otherwise an OTA
+        // image that broke STA but kept AP working would still be marked valid.
+        if (wifiManager.isConnected()) {
+            esp_ota_mark_app_valid_cancel_rollback();
+            LOG("BOOT", "Firmware marked valid");
+        }
     } else {
         LOG("BOOT", "WiFi not ready — web server will start when connected");
     }
@@ -161,14 +170,21 @@ void setup() {
 
     LOG("BOOT", "System initialization complete");
 
-    // User-facing boot banner (visible in serial monitor / flash tool)
-    if (wifiManager.isConnected()) {
-        SerialMenu::printBanner("OpenNeato", FIRMWARE_VERSION,
-                                "WiFi: " + WiFi.SSID() + " (" + WiFi.localIP().toString() + ")",
-                                "Press 'm' for menu, 's' for status");
-    } else {
-        SerialMenu::printBanner("OpenNeato", FIRMWARE_VERSION, "WiFi: not configured");
-    }
+    // User-facing boot banner (visible in serial monitor / flash tool).
+    // Build the status line from the current WiFi state, then call
+    // printBanner once (a single call avoids bugprone-branch-clone warnings
+    // from clang-tidy for chained conditionals that all end the same way).
+    auto bannerStatus = [&]() -> String {
+        if (wifiManager.isConnected())
+            return "WiFi: " + WiFi.SSID() + " (" + WiFi.localIP().toString() + ")";
+        if (wifiManager.isApActive())
+            return "WiFi: AP mode, connect to " + (settingsManager.get().hostname + String(AP_SSID_SUFFIX)) +
+                   " and open http://" + WiFi.softAPIP().toString();
+        return "WiFi: not configured";
+    }();
+    String bannerHint =
+            (wifiManager.isConnected() || wifiManager.isApActive()) ? "Press 'm' for menu, 's' for status" : "";
+    SerialMenu::printBanner("OpenNeato", FIRMWARE_VERSION, bannerStatus, bannerHint);
 
     // Show WiFi config menu if needed
     if (!wifiManager.isConnected()) {
@@ -189,17 +205,20 @@ void loop() {
     // WiFi auto-reconnect with exponential backoff
     wifiManager.loop();
 
-    // Deferred web server start — if WiFi was slow at boot (e.g. DHCP timeout
-    // after OTA), start the web server once WiFi eventually connects.
-    if (!webServerStarted && wifiManager.isConnected()) {
-        LOG("MAIN", "WiFi connected late — starting web server now");
+    // Deferred web server start , if WiFi was slow at boot (e.g. DHCP timeout
+    // after OTA), start the web server once WiFi eventually connects, or once
+    // the fallback AP comes up so the user can reconfigure WiFi from a browser.
+    if (!webServerStarted && (wifiManager.isConnected() || wifiManager.isApActive())) {
+        LOG("MAIN", "WiFi available late , starting web server now");
         dataLogger.logWifi("deferred_start");
         webServer.begin();
         server.begin();
         webServerStarted = true;
 
-        esp_ota_mark_app_valid_cancel_rollback();
-        LOG("MAIN", "Firmware marked valid (deferred)");
+        if (wifiManager.isConnected()) {
+            esp_ota_mark_app_valid_cancel_rollback();
+            LOG("MAIN", "Firmware marked valid (deferred)");
+        }
     }
 
     // Check for button press (runtime reset)
@@ -227,8 +246,10 @@ void loop() {
         }
     }
 
-    // Firmware update handling (only if connected)
-    if (wifiManager.isConnected()) {
+    // Firmware update handling , runs while either STA or fallback AP is up so
+    // the user can recover from a broken STA config by uploading firmware over
+    // the AP.
+    if (wifiManager.isConnected() || wifiManager.isApActive()) {
         firmwareManager.loop();
 
         // Skip other operations during firmware update

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -63,6 +63,7 @@ void SettingsManager::load() {
     current.brushRpm = prefs.getInt(NVS_KEY_MC_BRUSH_RPM, MANUAL_BRUSH_RPM);
     current.vacuumSpeed = prefs.getInt(NVS_KEY_MC_VACUUM_PCT, MANUAL_VACUUM_SPEED_PCT);
     current.sideBrushPower = prefs.getInt(NVS_KEY_MC_SBRUSH_MW, MANUAL_SIDE_BRUSH_POWER_MW);
+    current.apFallbackOnDisconnect = prefs.getBool(NVS_KEY_AP_FALLBACK, true);
     current.syslogEnabled = prefs.getBool(NVS_KEY_SYSLOG_ENABLED, false);
     current.syslogIp = prefs.getString(NVS_KEY_SYSLOG_IP, "");
     current.ntfyTopic = prefs.getString(NVS_KEY_NTFY_TOPIC, "");
@@ -93,6 +94,7 @@ void SettingsManager::save() {
     prefs.putInt(NVS_KEY_MC_BRUSH_RPM, current.brushRpm);
     prefs.putInt(NVS_KEY_MC_VACUUM_PCT, current.vacuumSpeed);
     prefs.putInt(NVS_KEY_MC_SBRUSH_MW, current.sideBrushPower);
+    prefs.putBool(NVS_KEY_AP_FALLBACK, current.apFallbackOnDisconnect);
     prefs.putBool(NVS_KEY_SYSLOG_ENABLED, current.syslogEnabled);
     prefs.putString(NVS_KEY_SYSLOG_IP, current.syslogIp);
     prefs.putString(NVS_KEY_NTFY_TOPIC, current.ntfyTopic);
@@ -250,6 +252,14 @@ ApplyResult SettingsManager::apply(const String& json) {
         LOG("SETTINGS", "Side brush power -> %d mW", current.sideBrushPower);
     }
 
+    if (incoming.apFallbackOnDisconnect != current.apFallbackOnDisconnect) {
+        current.apFallbackOnDisconnect = incoming.apFallbackOnDisconnect;
+        changed = true;
+        if (apFallbackChangeCb)
+            apFallbackChangeCb(current.apFallbackOnDisconnect);
+        LOG("SETTINGS", "AP fallback -> %s", current.apFallbackOnDisconnect ? "on" : "off");
+    }
+
     if (incoming.syslogEnabled != current.syslogEnabled) {
         current.syslogEnabled = incoming.syslogEnabled;
         changed = true;
@@ -343,6 +353,7 @@ std::vector<Field> Settings::toFields() const {
             {"brushRpm", String(brushRpm), FIELD_INT},
             {"vacuumSpeed", String(vacuumSpeed), FIELD_INT},
             {"sideBrushPower", String(sideBrushPower), FIELD_INT},
+            {"apFallbackOnDisconnect", apFallbackOnDisconnect ? "true" : "false", FIELD_BOOL},
             {"syslogEnabled", syslogEnabled ? "true" : "false", FIELD_BOOL},
             {"syslogIp", syslogIp, FIELD_STRING},
             {"ntfyTopic", ntfyTopic, FIELD_STRING},
@@ -414,6 +425,10 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
     }
     if ((f = findField(fields, "sideBrushPower")) && f->type == FIELD_INT) {
         sideBrushPower = f->value.toInt();
+        applied = true;
+    }
+    if ((f = findField(fields, "apFallbackOnDisconnect")) && f->type == FIELD_BOOL) {
+        apFallbackOnDisconnect = (f->value == "true");
         applied = true;
     }
     if ((f = findField(fields, "syslogEnabled")) && f->type == FIELD_BOOL) {

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -35,6 +35,11 @@ struct Settings : public JsonSerializable {
     int vacuumSpeed = MANUAL_VACUUM_SPEED_PCT; // Vacuum speed % (40-100)
     int sideBrushPower = MANUAL_SIDE_BRUSH_POWER_MW; // Side brush power in mW (500-1500)
 
+    // Fallback Access Point , when STA connection is lost, expose an AP for
+    // browser-based reconfiguration. Always on when no STA credentials are
+    // saved; controlled by this flag once credentials exist.
+    bool apFallbackOnDisconnect = true;
+
     // Remote syslog (UDP) — when enabled, logs go to network instead of flash
     bool syslogEnabled = false;
     String syslogIp; // IPv4 address of syslog receiver
@@ -81,12 +86,18 @@ public:
     using RebootCallback = std::function<void()>;
     void onRebootRequired(RebootCallback cb) { rebootCb = cb; }
 
+    // Callback fired when AP fallback policy changes (so WiFiManager can
+    // re-evaluate whether the AP should be active right now).
+    using ApFallbackChangeCallback = std::function<void(bool enabled)>;
+    void onApFallbackChange(ApFallbackChangeCallback cb) { apFallbackChangeCb = cb; }
+
 private:
     Preferences& prefs;
     Settings current;
     TzChangeCallback tzChangeCb;
     TxPowerChangeCallback txPowerChangeCb;
     RebootCallback rebootCb;
+    ApFallbackChangeCallback apFallbackChangeCb;
     unsigned long logLevelEnabledAt = 0; // millis() when log level was changed from off (0 = off/never)
 
     void load();

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -8,15 +8,16 @@
 #include "manual_clean_manager.h"
 #include "notification_manager.h"
 #include "cleaning_history.h"
+#include "wifi_manager.h"
 #include <SPIFFS.h>
 
 unsigned long WebServer::lastApiActivity = 0;
 
 WebServer::WebServer(AsyncWebServer& server, NeatoSerial& neato, DataLogger& logger, SystemManager& sys,
                      FirmwareManager& fw, SettingsManager& settings, ManualCleanManager& manual,
-                     NotificationManager& notif, CleaningHistory& history) :
+                     NotificationManager& notif, CleaningHistory& history, WiFiManager& wifi) :
     server(server), neato(neato), logger(logger), sysMgr(sys), fwMgr(fw), settingsMgr(settings), manualMgr(manual),
-    notifMgr(notif), historyMgr(history) {}
+    notifMgr(notif), historyMgr(history), wifiMgr(wifi) {}
 
 void WebServer::loggedRoute(const char *path, WebRequestMethodComposite httpMethod, SyncHandler handler) {
     server.on(path, httpMethod, [this, handler](AsyncWebServerRequest *request) {
@@ -71,6 +72,7 @@ void WebServer::begin() {
     registerSettingsRoutes();
     registerFirmwareRoutes();
     registerMapRoutes();
+    registerWiFiRoutes();
 
     LOG("WEB", "Frontend and API routes registered");
 }
@@ -504,4 +506,24 @@ void WebServer::registerMapRoutes() {
             });
 
     LOG("WEB", "History routes registered");
+}
+
+// -- WiFi management endpoints -----------------------------------------------
+
+void WebServer::registerWiFiRoutes() {
+    // GET /api/wifi/status , STA + fallback AP snapshot
+    registerGetRoute("/api/wifi/status", wifiMgr, &WiFiManager::getStatus, {});
+
+    // GET /api/wifi/scan , list nearby networks
+    registerGetRoute("/api/wifi/scan", wifiMgr, &WiFiManager::scanNetworks, {});
+
+    // POST /api/wifi/connect?ssid=&password= , save credentials and connect.
+    // On success the device reboots into normal STA mode; on failure the
+    // fallback AP stays up so the user can retry.
+    registerPostRoute("/api/wifi/connect", wifiMgr, &WiFiManager::connect, {"ssid", "password"});
+
+    // POST /api/wifi/disconnect , clear credentials and drop the connection
+    registerPostRoute("/api/wifi/disconnect", wifiMgr, &WiFiManager::disconnect, {});
+
+    LOG("WEB", "WiFi routes registered");
 }

--- a/firmware/src/web_server.h
+++ b/firmware/src/web_server.h
@@ -17,12 +17,13 @@ class SettingsManager;
 class ManualCleanManager;
 class NotificationManager;
 class CleaningHistory;
+class WiFiManager;
 
 class WebServer {
 public:
     WebServer(AsyncWebServer& server, NeatoSerial& neato, DataLogger& logger, SystemManager& sys, FirmwareManager& fw,
               SettingsManager& settings, ManualCleanManager& manual, NotificationManager& notif,
-              CleaningHistory& history);
+              CleaningHistory& history, WiFiManager& wifi);
     void begin();
 
     // Last time any API request was received (millis()). Any module can check
@@ -39,6 +40,7 @@ private:
     ManualCleanManager& manualMgr;
     NotificationManager& notifMgr;
     CleaningHistory& historyMgr;
+    WiFiManager& wifiMgr;
 
     void registerApiRoutes();
     void registerManualRoutes();
@@ -47,6 +49,7 @@ private:
     void registerSettingsRoutes();
     void registerFirmwareRoutes();
     void registerMapRoutes();
+    void registerWiFiRoutes();
     static void sendGzipAsset(AsyncWebServerRequest *request, const uint8_t *data, size_t len, const char *contentType);
     static void sendError(AsyncWebServerRequest *request, int code, const String& msg);
     static void sendOk(AsyncWebServerRequest *request);

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -3,6 +3,44 @@
 #include <esp_task_wdt.h>
 #include <esp_wifi.h>
 
+// -- Helper structs ----------------------------------------------------------
+
+std::vector<Field> WiFiStatus::toFields() const {
+    return {
+            {"staConnected", staConnected ? "true" : "false", FIELD_BOOL},
+            {"ssid", ssid, FIELD_STRING},
+            {"ip", ip, FIELD_STRING},
+            {"rssi", String(rssi), FIELD_INT},
+            {"apActive", apActive ? "true" : "false", FIELD_BOOL},
+            {"apSsid", apSsid, FIELD_STRING},
+            {"apIp", apIp, FIELD_STRING},
+            {"apClients", String(apClients), FIELD_INT},
+            {"apFallbackOnDisconnect", apFallbackOnDisconnect ? "true" : "false", FIELD_BOOL},
+            {"lastError", lastError, FIELD_STRING},
+    };
+}
+
+std::vector<Field> WiFiNetwork::toFields() const {
+    return {
+            {"ssid", ssid, FIELD_STRING},
+            {"rssi", String(rssi), FIELD_INT},
+            {"open", open ? "true" : "false", FIELD_BOOL},
+    };
+}
+
+String WiFiScanResult::toJson() const {
+    String json = "{\"networks\":[";
+    for (size_t i = 0; i < networks.size(); i++) {
+        if (i > 0)
+            json += ",";
+        json += networks[i].toJson();
+    }
+    json += "]}";
+    return json;
+}
+
+// -- WiFiManager -------------------------------------------------------------
+
 WiFiManager::WiFiManager(Preferences& prefs, DataLogger& logger) :
     LoopTask(WIFI_RECONNECT_INTERVAL), prefs(prefs), dataLogger(logger), menu("WiFi Configuration Menu"),
     networkMenu("Available WiFi Networks") {}
@@ -29,6 +67,7 @@ void WiFiManager::begin() {
             return;
         }
         LOG("WIFI", "Failed to connect with saved credentials");
+        lastStaError = wifiStatusReason(WiFi.status());
 
         // Log boot connection failure
         dataLogger.logWifi("boot_connect_fail",
@@ -40,6 +79,9 @@ void WiFiManager::begin() {
     // No credentials or connection failed
     LOG("WIFI", "WiFi not configured!");
     inConfigMode = true;
+
+    // Bring up the fallback AP so users can provision via browser
+    reevaluateFallbackAp();
 }
 
 void WiFiManager::showMenu() {
@@ -48,7 +90,7 @@ void WiFiManager::showMenu() {
 
     // Build menu items
     menu.clearItems();
-    menu.addItem("Scan WiFi networks", "Scan and select from available networks", [this]() { scanNetworks(); });
+    menu.addItem("Scan WiFi networks", "Scan and select from available networks", [this]() { scanNetworksMenu(); });
     menu.addItem("Enter SSID manually", "Type network name manually", [this]() { manualSSID(); });
     menu.addItem("Show current status", "Display WiFi connection status", [this]() { showStatus(); });
     menu.addItem("Reset all settings", "Erase all saved settings and restart", [this]() { resetCredentials(); });
@@ -94,6 +136,10 @@ void WiFiManager::handleSerialInput() {
             if (loadCredentials(ssid, pass)) {
                 menu.printKeyValue("Saved SSID", ssid);
             }
+            if (apActive) {
+                menu.printKeyValue("Fallback AP", apSsidName());
+                menu.printKeyValue("AP IP", WiFi.softAPIP().toString());
+            }
             menu.printSeparator();
             menu.printStatus("Quick commands: [m]enu, [s]tatus");
         } else if (c != '\n' && c != '\r') {
@@ -106,7 +152,7 @@ void WiFiManager::handleSerialInput() {
     }
 }
 
-void WiFiManager::scanNetworks() {
+void WiFiManager::scanNetworksMenu() {
     menu.printStatus("Scanning WiFi networks...");
     scannedNetworkCount = WiFi.scanNetworks();
 
@@ -246,6 +292,12 @@ void WiFiManager::showStatus() {
         menu.printKeyValue("Saved SSID", ssid);
     }
 
+    if (apActive) {
+        menu.printKeyValue("Fallback AP", apSsidName());
+        menu.printKeyValue("AP IP", WiFi.softAPIP().toString());
+        menu.printKeyValue("AP clients", String(WiFi.softAPgetStationNum()));
+    }
+
     menu.printSeparator();
     menu.printStatus(""); // Print newline
 
@@ -273,7 +325,9 @@ bool WiFiManager::connectToWiFi(const String& ssid, const String& password) {
     delay(100);
 
     WiFi.setHostname(hostname.c_str());
-    WiFi.mode(WIFI_STA);
+    // Use AP+STA mode if the fallback AP is currently active so we keep
+    // serving the provisioning page during the connection attempt.
+    WiFi.mode(apActive ? WIFI_AP_STA : WIFI_STA);
     // Enable modem sleep — radio powers down between AP beacons (~100ms),
     // reducing idle current from ~120mA to ~15-20mA. WiFi association stays
     // active; AP buffers frames during sleep. TX power is unaffected.
@@ -300,8 +354,10 @@ bool WiFiManager::connectToWiFi(const String& ssid, const String& password) {
         wasConnected = true;
         reconnectBackoff = WIFI_RECONNECT_INTERVAL;
         reconnectAttemptCount = 0;
+        lastStaError = "";
     } else {
         LOG("WIFI", "Connect failed after %lu ms (%d attempts), status=%d", connectMs, attempts, WiFi.status());
+        lastStaError = wifiStatusReason(WiFi.status());
         // Enable auto-reconnect even if boot connect timed out (e.g. slow DHCP).
         // WiFi may still be associating in the background — let loop() handle
         // reconnection so the deferred web server start can pick it up.
@@ -322,7 +378,16 @@ void WiFiManager::setTxPower(int quarterDbm) {
     LOG("WIFI", "TX power updated to %.1f dBm", quarterDbm * 0.25f);
 }
 
+void WiFiManager::setApFallbackOnDisconnect(bool enabled) {
+    apFallbackOnDisconnect = enabled;
+    reevaluateFallbackAp();
+}
+
 void WiFiManager::tick() {
+    // Re-evaluate the AP regardless of STA state , this also handles the
+    // recovery case where credentials are wiped via the API.
+    reevaluateFallbackAp();
+
     // Only attempt auto-reconnect if we were previously connected and are not
     // in config mode (user is actively setting up WiFi through the serial menu)
     if (inConfigMode || !wasConnected || WiFi.status() == WL_CONNECTED)
@@ -365,11 +430,13 @@ void WiFiManager::tick() {
         reconnectBackoff = WIFI_RECONNECT_INTERVAL; // Reset backoff on success
         setInterval(reconnectBackoff);
         reconnectAttemptCount = 0;
+        lastStaError = "";
     } else {
         // Exponential backoff: 5s -> 10s -> 20s -> 30s (capped)
         reconnectBackoff = min(reconnectBackoff * 2, static_cast<unsigned long>(WIFI_MAX_RECONNECT_BACKOFF));
         setInterval(reconnectBackoff);
         LOG("WIFI", "Reconnect failed (status=%d), next attempt in %lu ms", WiFi.status(), reconnectBackoff);
+        lastStaError = wifiStatusReason(WiFi.status());
 
         dataLogger.logWifi("reconnect_fail", {{"ssid", ssid, FIELD_STRING},
                                               {"status", String(WiFi.status()), FIELD_INT},
@@ -414,6 +481,180 @@ bool WiFiManager::loadCredentials(String& ssid, String& password) {
     return ssid.length() > 0;
 }
 
+bool WiFiManager::hasSavedCredentials() {
+    String ssid, password;
+    return loadCredentials(ssid, password);
+}
+
 bool WiFiManager::isConnected() const {
     return WiFi.status() == WL_CONNECTED;
+}
+
+// -- Fallback AP -------------------------------------------------------------
+
+String WiFiManager::apSsidName() const {
+    return hostname + AP_SSID_SUFFIX;
+}
+
+void WiFiManager::startAccessPoint() {
+    if (apActive)
+        return;
+
+    String ssid = apSsidName();
+    LOG("WIFI", "Starting fallback AP: %s", ssid.c_str());
+
+    // Combined AP+STA so the device can keep trying STA reconnects while the
+    // AP is up. Pure-AP mode would block reconnect attempts entirely.
+    WiFi.mode(WIFI_AP_STA);
+    WiFi.softAPConfig(AP_DEFAULT_IP, AP_GATEWAY, AP_SUBNET);
+    bool ok = WiFi.softAP(ssid.c_str(), nullptr, AP_CHANNEL, /*ssid_hidden=*/0, AP_MAX_CONNECTIONS);
+    if (!ok) {
+        LOG("WIFI", "softAP() failed");
+        dataLogger.logWifi("ap_start_fail", {{"ssid", ssid, FIELD_STRING}});
+        return;
+    }
+
+    apActive = true;
+    LOG("WIFI", "AP active: SSID=%s IP=%s", ssid.c_str(), WiFi.softAPIP().toString().c_str());
+    dataLogger.logWifi("ap_start", {{"ssid", ssid, FIELD_STRING}, {"ip", WiFi.softAPIP().toString(), FIELD_STRING}});
+}
+
+void WiFiManager::stopAccessPoint() {
+    if (!apActive)
+        return;
+
+    LOG("WIFI", "Stopping fallback AP");
+    WiFi.softAPdisconnect(true);
+    // If STA is still wanted, keep STA mode active; otherwise drop to STA-only
+    // so the radio doesn't sit in AP+STA with no AP.
+    WiFi.mode(WIFI_STA);
+    apActive = false;
+    dataLogger.logWifi("ap_stop");
+}
+
+void WiFiManager::reevaluateFallbackAp() {
+    // Three policies, derived from the issue scope:
+    //   1. No saved credentials -> AP always on (only way to provision).
+    //   2. STA connected -> AP off.
+    //   3. Saved credentials but STA disconnected -> AP on iff
+    //      apFallbackOnDisconnect is true.
+    bool credsSaved = hasSavedCredentials();
+    bool staConnected = WiFi.status() == WL_CONNECTED;
+
+    bool wantAp;
+    if (!credsSaved) {
+        wantAp = true;
+    } else if (staConnected) {
+        wantAp = false;
+    } else {
+        wantAp = apFallbackOnDisconnect;
+    }
+
+    if (wantAp && !apActive) {
+        startAccessPoint();
+    } else if (!wantAp && apActive) {
+        stopAccessPoint();
+    }
+}
+
+// -- API surface -------------------------------------------------------------
+
+void WiFiManager::getStatus(std::function<void(bool, const WiFiStatus&)> cb) {
+    WiFiStatus s;
+    s.staConnected = isConnected();
+    if (s.staConnected) {
+        s.ssid = WiFi.SSID();
+        s.ip = WiFi.localIP().toString();
+        s.rssi = WiFi.RSSI();
+    } else {
+        // Fall back to saved SSID so the UI can show "trying to reconnect to X"
+        String savedPass;
+        loadCredentials(s.ssid, savedPass);
+    }
+    s.apActive = apActive;
+    if (apActive) {
+        s.apSsid = apSsidName();
+        s.apIp = WiFi.softAPIP().toString();
+        s.apClients = WiFi.softAPgetStationNum();
+    }
+    s.apFallbackOnDisconnect = apFallbackOnDisconnect;
+    s.lastError = lastStaError;
+    cb(true, s);
+}
+
+void WiFiManager::scanNetworks(std::function<void(bool, const WiFiScanResult&)> cb) {
+    WiFiScanResult result;
+
+    // Use synchronous scan with watchdog feeding so a slow scan doesn't
+    // trigger a TWDT reset. Returns the network count or a negative error.
+    int n = WiFi.scanNetworks(/*async=*/false, /*show_hidden=*/false);
+    esp_task_wdt_reset();
+
+    if (n < 0) {
+        LOG("WIFI", "Scan failed: %d", n);
+        cb(false, result);
+        return;
+    }
+
+    // Cap at 30 entries , anything more than that on an ESP32-C3 is noise
+    // and would just bloat the JSON response.
+    int max = n < 30 ? n : 30;
+    result.networks.reserve(max);
+    for (int i = 0; i < max; ++i) {
+        WiFiNetwork net;
+        net.ssid = WiFi.SSID(i);
+        net.rssi = WiFi.RSSI(i);
+        net.open = WiFi.encryptionType(i) == WIFI_AUTH_OPEN;
+        result.networks.push_back(net);
+    }
+    WiFi.scanDelete();
+
+    cb(true, result);
+}
+
+bool WiFiManager::connect(const String& ssid, const String& password, std::function<void(bool)> cb) {
+    if (ssid.isEmpty()) {
+        cb(false);
+        return true; // Handler ran (returned an error) , don't return 503
+    }
+
+    LOG("WIFI", "API connect request: %s", ssid.c_str());
+    dataLogger.logWifi("api_connect", {{"ssid", ssid, FIELD_STRING}});
+
+    // Save first so a successful connection leads to a normal reboot path
+    // and a failure can be inspected via the AP afterwards.
+    saveCredentials(ssid, password);
+
+    bool ok = connectToWiFi(ssid, password);
+    if (ok) {
+        // Schedule a reboot so the regular boot flow brings up the web server,
+        // mDNS, etc. with the freshly connected STA. Give the response time
+        // to flush first.
+        cb(true);
+        delay(500);
+        ESP.restart();
+        return true;
+    }
+
+    // Connection failed , keep AP up so the user can try again.
+    reevaluateFallbackAp();
+    cb(false);
+    return true;
+}
+
+bool WiFiManager::disconnect(std::function<void(bool)> cb) {
+    LOG("WIFI", "API disconnect request");
+    dataLogger.logWifi("api_disconnect");
+
+    prefs.remove(NVS_KEY_WIFI_SSID);
+    prefs.remove(NVS_KEY_WIFI_PASS);
+    WiFi.disconnect(true, true);
+    wasConnected = false;
+    lastStaError = "";
+
+    // No credentials -> AP must be up regardless of policy
+    reevaluateFallbackAp();
+
+    cb(true);
+    return true;
 }

--- a/firmware/src/wifi_manager.h
+++ b/firmware/src/wifi_manager.h
@@ -3,11 +3,47 @@
 
 #include <WiFi.h>
 #include <Preferences.h>
+#include <functional>
+#include <vector>
 #include "config.h"
+#include "json_fields.h"
 #include "loop_task.h"
 #include "serial_menu.h"
 
 class DataLogger;
+
+// Status of an STA connection attempt initiated via the API.
+struct WiFiStatus : public JsonSerializable {
+    bool staConnected = false;
+    String ssid;
+    String ip;
+    int rssi = 0;
+    bool apActive = false;
+    String apSsid;
+    String apIp;
+    int apClients = 0;
+    bool apFallbackOnDisconnect = true;
+    String lastError; // Empty when no error; otherwise human-readable failure reason
+
+    std::vector<Field> toFields() const override;
+};
+
+// Single network result from a scan.
+struct WiFiNetwork : public JsonSerializable {
+    String ssid;
+    int rssi = 0;
+    bool open = false;
+
+    std::vector<Field> toFields() const override;
+};
+
+// Scan result list , wraps a vector of networks for JSON serialization.
+struct WiFiScanResult : public JsonSerializable {
+    std::vector<WiFiNetwork> networks;
+
+    std::vector<Field> toFields() const override { return {}; } // Unused , toJson is overridden
+    String toJson() const;
+};
 
 class WiFiManager : public LoopTask {
 public:
@@ -21,11 +57,37 @@ public:
 
     bool isConnected() const;
 
+    // True when the fallback AP is currently broadcasting. Used by main.cpp
+    // to decide whether the web server should come up even without STA.
+    bool isApActive() const { return apActive; }
+
     // Set hostname for WiFi/mDNS. Must be called before begin() or takes effect on next reboot.
     void setHostname(const String& name) { hostname = name; }
 
     // Apply TX power setting (0.25 dBm units). Safe to call at any time.
     void setTxPower(int quarterDbm);
+
+    // Update the fallback-on-disconnect policy and re-evaluate AP state.
+    void setApFallbackOnDisconnect(bool enabled);
+
+    // -- API-driven WiFi management ------------------------------------------
+    // These methods follow the registerGetRoute / registerPostRoute callback
+    // shape so they can be wired directly from the web server.
+
+    // Snapshot current STA + AP state. Always succeeds.
+    void getStatus(std::function<void(bool, const WiFiStatus&)> cb);
+
+    // Trigger a synchronous WiFi.scanNetworks() and report results.
+    // Blocks the calling task for ~2s; only invoked from API handlers.
+    void scanNetworks(std::function<void(bool, const WiFiScanResult&)> cb);
+
+    // Save credentials, attempt connection. Reboots on success so the
+    // new STA setup goes through the regular boot path.
+    bool connect(const String& ssid, const String& password, std::function<void(bool)> cb);
+
+    // Clear saved credentials and disconnect the STA. AP comes up
+    // automatically after the disconnect (no credentials saved).
+    bool disconnect(std::function<void(bool)> cb);
 
 private:
     Preferences& prefs;
@@ -37,6 +99,11 @@ private:
     bool inNetworkSelection = false;
     String selectedSSID = "";
     int scannedNetworkCount = 0;
+
+    // Fallback AP state
+    bool apActive = false;
+    bool apFallbackOnDisconnect = true; // Mirrors setting; updated via setApFallbackOnDisconnect
+    String lastStaError; // Last STA failure reason (cleared on successful connect)
 
     void tick() override; // Called by LoopTask::loop() at WIFI_RECONNECT_INTERVAL cadence
 
@@ -54,8 +121,18 @@ private:
 
     bool loadCredentials(String& ssid, String& password);
 
+    bool hasSavedCredentials();
+
+    // Fallback AP lifecycle
+    String apSsidName() const; // Returns "<hostname>-ap"
+    void startAccessPoint();
+    void stopAccessPoint();
+    // Decide whether the AP should be on and bring it up / down accordingly.
+    // Called whenever STA state, credentials, or apFallbackOnDisconnect change.
+    void reevaluateFallbackAp();
+
     // Menu actions
-    void scanNetworks();
+    void scanNetworksMenu();
     void manualSSID();
     void showStatus();
     void resetCredentials();

--- a/frontend/api/openapi.yaml
+++ b/frontend/api/openapi.yaml
@@ -18,6 +18,8 @@ tags:
     description: Manual cleaning mode (joystick, motors)
   - name: Logs
     description: Diagnostic log files stored in flash
+  - name: WiFi
+    description: WiFi station status and provisioning over the fallback AP
   - name: System
     description: ESP32 system health and lifecycle
   - name: Settings
@@ -533,6 +535,70 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/wifi/status:
+    get:
+      tags:
+        - WiFi
+      summary: Get current WiFi STA + fallback AP status snapshot
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WiFiStatus"
+  /api/wifi/scan:
+    get:
+      tags:
+        - WiFi
+      summary: Scan for nearby WiFi networks (synchronous, capped at 30 entries)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WiFiScanResult"
+        "500":
+          description: scan failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/wifi/connect:
+    post:
+      tags:
+        - WiFi
+      summary: Save credentials and connect to a WiFi network (reboots on success)
+      parameters:
+        - name: ssid
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          required: true
+          description: Empty string for open networks
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: "#/components/responses/Ok"
+        "400":
+          description: missing ssid or connection failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/wifi/disconnect:
+    post:
+      tags:
+        - WiFi
+      summary: Clear saved credentials and drop the STA connection
+      responses:
+        "200":
+          $ref: "#/components/responses/Ok"
   /api/system:
     get:
       tags:
@@ -1177,6 +1243,9 @@ components:
         logLevel:
           type: number
           description: 0=off, 1=info, 2=debug
+        apFallbackOnDisconnect:
+          type: boolean
+          description: Bring up the fallback AP automatically when STA drops
         syslogEnabled:
           type: boolean
           description: When on, logs go to UDP syslog instead of flash
@@ -1321,6 +1390,7 @@ components:
       required:
         - tz
         - logLevel
+        - apFallbackOnDisconnect
         - syslogEnabled
         - syslogIp
         - wifiTxPower
@@ -1520,6 +1590,74 @@ components:
         - totalRotation
         - areaCovered
         - errorsDuringClean
+    WiFiStatus:
+      type: object
+      properties:
+        staConnected:
+          type: boolean
+          description: Station mode connected to an upstream AP
+        ssid:
+          type: string
+          description: Connected SSID, or last saved SSID when disconnected
+        ip:
+          type: string
+          description: STA IPv4 address (empty when disconnected)
+        rssi:
+          type: integer
+          description: STA signal strength in dBm (0 when disconnected)
+        apActive:
+          type: boolean
+          description: Fallback AP currently broadcasting
+        apSsid:
+          type: string
+          description: Fallback AP SSID (empty when AP is down)
+        apIp:
+          type: string
+          description: Fallback AP IPv4 address (empty when AP is down)
+        apClients:
+          type: integer
+          description: Number of clients connected to the fallback AP
+        apFallbackOnDisconnect:
+          type: boolean
+          description: Whether the AP is brought up automatically when STA drops
+        lastError:
+          type: string
+          description: Human-readable description of the most recent STA failure
+      required:
+        - staConnected
+        - ssid
+        - ip
+        - rssi
+        - apActive
+        - apSsid
+        - apIp
+        - apClients
+        - apFallbackOnDisconnect
+        - lastError
+    WiFiNetwork:
+      type: object
+      properties:
+        ssid:
+          type: string
+        rssi:
+          type: integer
+          description: Signal strength in dBm
+        open:
+          type: boolean
+          description: True for open networks (no encryption)
+      required:
+        - ssid
+        - rssi
+        - open
+    WiFiScanResult:
+      type: object
+      properties:
+        networks:
+          type: array
+          items:
+            $ref: "#/components/schemas/WiFiNetwork"
+      required:
+        - networks
   responses:
     Ok:
       description: Success acknowledgement

--- a/frontend/mock/server.js
+++ b/frontend/mock/server.js
@@ -105,6 +105,15 @@ const _randf = (min, max, decimals = 2) => parseFloat((Math.random() * (max - mi
 //   fp   — All polling faults (state + charger + error)
 //   fhc  — History corruption (inject corrupted pose lines in session data)
 //   fhl  — History list corruption (malformed JSON in /api/history response, triggers recovery panel)
+//
+// WiFi:
+//   wap  , Fallback AP active (STA disconnected, fallback enabled)
+//   wnc  , No saved credentials (first boot, AP always on)
+//   wfo  , Fallback AP setting off (combine with wap to test off + disconnected)
+//   fws  , Scan fault: /api/wifi/scan returns 500
+//   fwn  , Empty scan: /api/wifi/scan returns no networks
+//   fwc  , Connect fault: /api/wifi/connect rejects with auth error
+//
 //   fal  — All faults combined
 const SCENARIO = "ok";
 
@@ -166,6 +175,12 @@ const SCENARIOS = {
     fp: { faults: { pollState: true, pollCharger: true, pollError: true } },
     fhc: { faults: { historyCorrupt: true } },
     fhl: { faults: { historyListCorrupt: true } },
+    wap: { wifiDisconnected: true },
+    wnc: { wifiDisconnected: true, wifiNoCredentials: true },
+    wfo: { apFallbackOnDisconnect: false },
+    fws: { faults: { wifiScan: true } },
+    fwn: { faults: { wifiScanEmpty: true } },
+    fwc: { faults: { wifiConnect: true } },
     fal: {
         faults: {
             actions: true,
@@ -177,6 +192,8 @@ const SCENARIOS = {
             pollError: true,
             historyCorrupt: true,
             historyListCorrupt: true,
+            wifiScan: true,
+            wifiConnect: true,
         },
     },
 };
@@ -202,6 +219,9 @@ const faults = {
     pollCharger: false,
     pollError: false,
     historyCorrupt: false,
+    wifiScan: false,
+    wifiScanEmpty: false,
+    wifiConnect: false,
     ...(merged.faults || {}),
 };
 
@@ -246,6 +266,12 @@ const state = {
     lidarSlowRotation: false,
     tz: "UTC0",
     logLevel: 0,
+    apFallbackOnDisconnect: true,
+    // WiFi mock state , `wifiDisconnected` flips STA to disconnected and
+    // brings up the fallback AP; `wifiNoCredentials` clears saved SSID so
+    // the UI shows the "first boot" path (no current network, no forget).
+    wifiDisconnected: false,
+    wifiNoCredentials: false,
     syslogEnabled: false,
     syslogIp: "",
     wifiTxPower: 60, // 15 dBm in 0.25 dBm units
@@ -743,6 +769,7 @@ const routes = {
         const keys = [
             "tz",
             "logLevel",
+            "apFallbackOnDisconnect",
             "syslogEnabled",
             "syslogIp",
             "wifiTxPower",
@@ -773,6 +800,59 @@ const routes = {
             s[`sched${d}Slot1On`] = state[`sched${d}Slot1On`];
         }
         jsonResponse(res, s);
+    },
+
+    "GET /api/wifi/status": (_req, res) => {
+        // No saved credentials: STA never reports a "last SSID" and the
+        // fallback AP is always up regardless of the toggle.
+        const hasCreds = !state.wifiNoCredentials;
+        const apOn = !!state.wifiDisconnected || !hasCreds;
+        jsonResponse(res, {
+            staConnected: !state.wifiDisconnected && hasCreds,
+            ssid: hasCreds ? "HomeWiFi" : "",
+            ip: state.wifiDisconnected || !hasCreds ? "" : "192.168.1.42",
+            rssi: state.wifiDisconnected || !hasCreds ? 0 : -52,
+            apActive: apOn,
+            apSsid: apOn ? `${state.hostname}-ap` : "",
+            apIp: apOn ? "192.168.4.1" : "",
+            apClients: apOn ? (hasCreds ? 1 : 0) : 0,
+            apFallbackOnDisconnect: state.apFallbackOnDisconnect,
+            lastError: state.wifiDisconnected && hasCreds ? "wrong password or authentication rejected" : "",
+        });
+    },
+
+    "GET /api/wifi/scan": async (_req, res) => {
+        // Simulate scan latency
+        await new Promise((r) => setTimeout(r, rand(800, 1500)));
+        if (faults.wifiScan) return sendError(res, "WiFi scan failed: radio busy", 500);
+        if (faults.wifiScanEmpty) return jsonResponse(res, { networks: [] });
+        jsonResponse(res, {
+            networks: [
+                { ssid: "HomeWiFi", rssi: -52, open: false },
+                { ssid: "Neighbour-5G", rssi: -68, open: false },
+                { ssid: "GuestNet", rssi: -71, open: true },
+                { ssid: "FritzBox-2", rssi: -78, open: false },
+                { ssid: "TP-Link-Guest", rssi: -82, open: true },
+            ],
+        });
+    },
+
+    "POST /api/wifi/connect": async (_req, res, query) => {
+        if (!query.ssid) return sendError(res, "missing ssid", 400);
+        await new Promise((r) => setTimeout(r, rand(500, 1500)));
+        if (faults.wifiConnect) {
+            return sendError(res, "wrong password or authentication rejected", 500);
+        }
+        // Simulate reboot path on success , caller will see the AP go away
+        state.wifiDisconnected = false;
+        state.wifiNoCredentials = false;
+        sendOk(res);
+    },
+
+    "POST /api/wifi/disconnect": (_req, res) => {
+        state.wifiDisconnected = true;
+        state.wifiNoCredentials = true;
+        sendOk(res);
     },
 
     "POST /api/notifications/test": (_req, res, query) => {
@@ -1075,6 +1155,7 @@ const handleRequest = async (req, res) => {
             await new Promise((r) => setTimeout(r, rand(300, 600)));
             if (data.tz !== undefined) state.tz = data.tz;
             if (data.logLevel !== undefined) state.logLevel = data.logLevel;
+            if (data.apFallbackOnDisconnect !== undefined) state.apFallbackOnDisconnect = data.apFallbackOnDisconnect;
             if (data.syslogEnabled !== undefined) state.syslogEnabled = data.syslogEnabled;
             if (data.syslogIp !== undefined) state.syslogIp = data.syslogIp;
             if (data.wifiTxPower !== undefined) state.wifiTxPower = data.wifiTxPower;
@@ -1115,6 +1196,7 @@ const handleRequest = async (req, res) => {
             const keys = [
                 "tz",
                 "logLevel",
+                "apFallbackOnDisconnect",
                 "syslogEnabled",
                 "syslogIp",
                 "wifiTxPower",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,6 +12,8 @@ import type {
     StateData,
     SystemData,
     UserSettingsData,
+    WiFiScanResult,
+    WiFiStatus,
 } from "./types";
 
 async function parseError(res: Response): Promise<string> {
@@ -184,4 +186,10 @@ export const api = {
     setUserSetting: (key: string, value: string) =>
         post(`/api/user-settings?key=${encodeURIComponent(key)}&value=${encodeURIComponent(value)}`),
     sendSerial: (cmd: string) => sendSerial(cmd),
+
+    getWifiStatus: () => get<WiFiStatus>("/api/wifi/status"),
+    scanWifi: () => get<WiFiScanResult>("/api/wifi/scan"),
+    connectWifi: (ssid: string, password: string) =>
+        post(`/api/wifi/connect?ssid=${encodeURIComponent(ssid)}&password=${encodeURIComponent(password)}`),
+    disconnectWifi: () => post("/api/wifi/disconnect"),
 };

--- a/frontend/src/assets/icons/globe.svg
+++ b/frontend/src/assets/icons/globe.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+</svg>

--- a/frontend/src/components/confirm-dialog.tsx
+++ b/frontend/src/components/confirm-dialog.tsx
@@ -3,29 +3,51 @@ import { useState } from "preact/hooks";
 interface ConfirmDialogProps {
     message: string;
     confirmLabel?: string;
-    confirmText?: string; // When set, user must type this exact text to enable confirm
+    // When true (default), the confirm button is rendered as a destructive
+    // (red) action. Set to false for benign confirmations like Connect.
+    destructive?: boolean;
+    // When set, user must type this exact text to enable confirm. Useful for
+    // destructive actions (e.g. "Type RESET to confirm").
+    confirmText?: string;
+    // Prompts the user for a free-form value (text or password). The entered
+    // value is passed to `onConfirm`. When `inputRequired` is true the
+    // confirm button is disabled until the field is non-empty.
+    inputType?: "text" | "password";
+    inputPlaceholder?: string;
+    inputLabel?: string;
+    inputRequired?: boolean;
     disabled?: boolean;
-    onConfirm: () => void;
+    onConfirm: (value?: string) => void;
     onCancel: () => void;
 }
 
 export function ConfirmDialog({
     message,
     confirmLabel = "Delete",
+    destructive = true,
     confirmText,
+    inputType,
+    inputPlaceholder,
+    inputLabel,
+    inputRequired = false,
     disabled = false,
     onConfirm,
     onCancel,
 }: ConfirmDialogProps) {
     const [typed, setTyped] = useState("");
+    const [value, setValue] = useState("");
     const textMatch = !confirmText || typed === confirmText;
+    const valueOk = !inputType || !inputRequired || value.length > 0;
 
     return (
         // biome-ignore lint/a11y/useKeyWithClickEvents: overlay dismiss is supplementary to Cancel button
         <div class="confirm-overlay" role="dialog" aria-modal="true" onClick={disabled ? undefined : onCancel}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation only, not interactive */}
             {/* biome-ignore lint/a11y/noStaticElementInteractions: dialog container */}
-            <div class="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+            <div
+                class={`confirm-dialog ${destructive ? "destructive" : "primary"}`}
+                onClick={(e) => e.stopPropagation()}
+            >
                 <div class="confirm-message">{message}</div>
                 {confirmText && (
                     <div class="confirm-text-input-wrap">
@@ -44,15 +66,35 @@ export function ConfirmDialog({
                         />
                     </div>
                 )}
+                {inputType && (
+                    <div class="confirm-text-input-wrap">
+                        {inputLabel && (
+                            <label class="confirm-text-label" htmlFor="confirm-input-value">
+                                {inputLabel}
+                            </label>
+                        )}
+                        <input
+                            id="confirm-input-value"
+                            type={inputType}
+                            class="confirm-text-input"
+                            value={value}
+                            onInput={(e) => setValue((e.target as HTMLInputElement).value)}
+                            placeholder={inputPlaceholder}
+                            autocomplete={inputType === "password" ? "current-password" : "off"}
+                            spellcheck={false}
+                            disabled={disabled}
+                        />
+                    </div>
+                )}
                 <div class="confirm-actions">
                     <button type="button" class="confirm-btn cancel" onClick={onCancel} disabled={disabled}>
                         Cancel
                     </button>
                     <button
                         type="button"
-                        class="confirm-btn destructive"
-                        onClick={onConfirm}
-                        disabled={disabled || !textMatch}
+                        class={`confirm-btn ${destructive ? "destructive" : "primary"}`}
+                        onClick={() => onConfirm(inputType ? value : undefined)}
+                        disabled={disabled || !textMatch || !valueOk}
                     >
                         {confirmLabel}
                     </button>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -494,10 +494,6 @@ body {
     transition: opacity 0.15s;
 }
 
-.update-banner:active {
-    opacity: 0.7;
-}
-
 .update-banner svg {
     width: 16px;
     height: 16px;
@@ -552,11 +548,14 @@ body {
 
 .action-btn:disabled {
     opacity: 0.3;
-    cursor: default;
     transform: none;
 }
 
-.action-btn.pending {
+/* -- Shared cross-cutting utilities --------------------------------------- */
+
+/* Pulse for any in-flight button or input. Components opt in by adding the
+   `pending` class while a request is running. */
+.pending {
     animation: btn-pulse 1s ease-in-out infinite;
 }
 
@@ -568,6 +567,33 @@ body {
     50% {
         opacity: 0.7;
     }
+}
+
+/* Default cursor on disabled controls , replaces per-element copies. */
+button:disabled,
+select:disabled,
+input:disabled {
+    cursor: default;
+}
+
+/* Press feedback for tappable elements. Listed explicitly because some
+   buttons have custom :active styles (transform-based scales) that we
+   don't want to dim. */
+.update-banner:active,
+.settings-category-header:active,
+.settings-nav-row:active,
+.settings-ntfy-test-btn:not(:disabled):active,
+.settings-wifi-scan-btn:not(:disabled):active,
+.fw-upload-btn:active,
+.settings-save-btn:active,
+.settings-device-btn:active,
+.confirm-btn:active,
+.logs-delete-all-btn:active,
+.logs-file-info:active,
+.history-recovery-link:active,
+.history-session-card:active,
+.history-delete-all-btn:active {
+    opacity: 0.7;
 }
 
 .action-btn.primary {
@@ -624,7 +650,6 @@ body {
 
 .header-back-btn:disabled {
     opacity: 0.3;
-    cursor: default;
     transform: none;
 }
 
@@ -689,10 +714,6 @@ body {
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     letter-spacing: 0.01em;
-}
-
-.settings-category-header:active {
-    opacity: 0.7;
 }
 
 .settings-category-title {
@@ -828,14 +849,6 @@ body {
     border-color: var(--accent);
 }
 
-.settings-tz-select:disabled {
-    cursor: default;
-}
-
-.settings-tz-select.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
-}
-
 .settings-robot-time {
     display: flex;
     align-items: center;
@@ -876,10 +889,6 @@ body {
     -webkit-tap-highlight-color: transparent;
 }
 
-.settings-nav-row:active {
-    opacity: 0.7;
-}
-
 .settings-nav-row-left {
     display: flex;
     align-items: center;
@@ -917,6 +926,13 @@ body {
     border-radius: 12px;
     background: var(--surface);
     margin-bottom: 10px;
+}
+
+/* Drop the trailing gap when the toggle is the last thing in its container,
+   so single-toggle sections don't show extra padding before the section
+   divider. Stacked toggles still get the 10px breathing room above. */
+.settings-toggle-row:last-child {
+    margin-bottom: 0;
 }
 
 .settings-toggle-label {
@@ -965,10 +981,6 @@ body {
     transition:
         transform 0.2s,
         background 0.2s;
-}
-
-.settings-toggle.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
 }
 
 .settings-toggle.on {
@@ -1069,11 +1081,44 @@ body {
 
 .settings-ntfy-test-btn:disabled {
     opacity: 0.4;
-    cursor: default;
 }
 
-.settings-ntfy-test-btn:not(:disabled):active {
-    opacity: 0.7;
+/* WiFi management section */
+
+.settings-wifi-pick-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+}
+
+.settings-wifi-select {
+    flex: 1;
+    min-width: 0;
+}
+
+.settings-wifi-scan-btn {
+    padding: 8px 16px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: opacity 0.15s;
+}
+
+.settings-wifi-scan-btn:disabled {
+    opacity: 0.4;
+}
+
+.settings-wifi-password {
+    margin-top: 10px;
+}
+
+.settings-wifi-connect-btn {
+    margin-top: 10px;
 }
 
 /* Firmware update section */
@@ -1185,10 +1230,6 @@ body {
     -webkit-tap-highlight-color: transparent;
 }
 
-.fw-upload-btn:active {
-    opacity: 0.7;
-}
-
 .fw-progress-wrap {
     display: flex;
     flex-direction: column;
@@ -1248,17 +1289,8 @@ body {
     -webkit-tap-highlight-color: transparent;
 }
 
-.settings-save-btn:active {
-    opacity: 0.7;
-}
-
 .settings-save-btn:disabled {
     opacity: 0.3;
-    cursor: default;
-}
-
-.settings-save-btn.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
 }
 
 /* Device action buttons */
@@ -1283,10 +1315,6 @@ body {
     font-family: inherit;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-}
-
-.settings-device-btn:active {
-    opacity: 0.7;
 }
 
 .settings-device-btn span {
@@ -1362,8 +1390,23 @@ body {
     outline: none;
 }
 
-.confirm-text-input:focus {
-    border-color: var(--red);
+/* Per-variant tone , drives the confirm button color. */
+.confirm-dialog.destructive {
+    --tone: var(--red);
+    --tone-bg: rgba(255, 69, 58, 0.12);
+    --tone-border: rgba(255, 69, 58, 0.2);
+}
+
+.confirm-dialog.primary {
+    --tone: var(--accent);
+    --tone-bg: rgba(249, 235, 178, 0.08);
+    --tone-border: var(--border-accent);
+}
+
+/* Tint the input focus on destructive dialogs to reinforce the "type X to
+   confirm" gate. Plain dialogs (Connect, password entry) use the default. */
+.confirm-dialog.destructive .confirm-text-input:focus {
+    border-color: var(--tone);
 }
 
 .confirm-actions {
@@ -1383,13 +1426,8 @@ body {
     -webkit-tap-highlight-color: transparent;
 }
 
-.confirm-btn:active {
-    opacity: 0.7;
-}
-
 .confirm-btn:disabled {
     opacity: 0.3;
-    cursor: default;
 }
 
 .confirm-btn.cancel {
@@ -1397,15 +1435,20 @@ body {
     color: var(--text);
 }
 
-.confirm-btn.destructive {
-    background: rgba(255, 69, 58, 0.12);
-    border-color: rgba(255, 69, 58, 0.2);
-    color: var(--red);
+.confirm-btn.destructive,
+.confirm-btn.primary {
+    background: var(--tone-bg);
+    border-color: var(--tone-border);
+    color: var(--tone);
 }
 
-/* Reboot overlay */
+.confirm-btn.primary {
+    font-weight: 700;
+}
 
-.reboot-overlay {
+/* Full-screen loading overlay (reboot, WiFi connect, etc.) */
+
+.loading-overlay {
     position: fixed;
     inset: 0;
     z-index: 200;
@@ -1418,7 +1461,7 @@ body {
     backdrop-filter: blur(4px);
 }
 
-.reboot-dialog {
+.loading-dialog {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -1431,28 +1474,30 @@ body {
     max-width: 260px;
 }
 
-.reboot-spinner {
+.loading-spinner {
     width: 36px;
     height: 36px;
     border: 3px solid var(--border);
     border-top-color: var(--accent);
     border-radius: 50%;
-    animation: reboot-spin 0.8s linear infinite;
+    animation: loading-spin 0.8s linear infinite;
 }
 
-@keyframes reboot-spin {
+@keyframes loading-spin {
     to {
         transform: rotate(360deg);
     }
 }
 
-.reboot-text {
+.loading-text {
     font-size: 16px;
     font-weight: 600;
     color: var(--text);
+    text-align: center;
+    word-break: break-word;
 }
 
-.reboot-subtext {
+.loading-subtext {
     font-size: 12px;
     font-weight: 500;
     color: var(--text-muted);
@@ -1489,18 +1534,6 @@ body {
     font-family: inherit;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-}
-
-.logs-delete-all-btn:active {
-    opacity: 0.7;
-}
-
-.logs-delete-all-btn:disabled {
-    cursor: default;
-}
-
-.logs-delete-all-btn.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
 }
 
 .logs-empty {
@@ -1552,10 +1585,6 @@ body {
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     min-width: 0;
-}
-
-.logs-file-info:active {
-    opacity: 0.7;
 }
 
 .logs-file-name {
@@ -1623,14 +1652,6 @@ body {
 
 .logs-file-delete:active {
     opacity: 1;
-}
-
-.logs-file-delete:disabled {
-    cursor: default;
-}
-
-.logs-file-delete.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
 }
 
 .logs-file-delete span {
@@ -1924,10 +1945,6 @@ body {
     -webkit-tap-highlight-color: transparent;
 }
 
-.history-recovery-link:active {
-    opacity: 0.7;
-}
-
 .history-session-row {
     display: flex;
     align-items: center;
@@ -2000,10 +2017,6 @@ body {
     text-align: left;
     -webkit-tap-highlight-color: transparent;
     min-width: 0;
-}
-
-.history-session-card:active {
-    opacity: 0.7;
 }
 
 .history-session-download {
@@ -2165,18 +2178,6 @@ body {
     -webkit-tap-highlight-color: transparent;
 }
 
-.history-delete-all-btn:active {
-    opacity: 0.7;
-}
-
-.history-delete-all-btn:disabled {
-    cursor: default;
-}
-
-.history-delete-all-btn.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
-}
-
 .history-summary-actions {
     display: flex;
     gap: 8px;
@@ -2207,10 +2208,6 @@ body {
 
 .history-import-label:active .history-import-btn {
     opacity: 0.7;
-}
-
-.history-import-btn.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
 }
 
 .history-detail-stats {
@@ -2435,7 +2432,6 @@ body {
 
 .history-player-btn:disabled {
     opacity: 0.4;
-    cursor: default;
 }
 
 .history-player-btn span {
@@ -2668,7 +2664,6 @@ body {
 
 .sched-add-btn:disabled {
     opacity: 0.3;
-    cursor: default;
 }
 
 .sched-remove-btn {
@@ -2693,10 +2688,6 @@ body {
 
 .sched-remove-btn:active {
     opacity: 1;
-}
-
-.sched-remove-btn:disabled {
-    cursor: default;
 }
 
 .schedule-day-left {
@@ -2921,10 +2912,6 @@ body {
     background: var(--blue);
     color: #fff;
     border-color: var(--blue);
-}
-
-.manual-motor-btn.pending {
-    animation: btn-pulse 1s ease-in-out infinite;
 }
 
 .manual-motor-btn:active {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -18,6 +18,9 @@ export type {
     SystemData,
     UserSettingsData,
     VersionData,
+    WiFiNetwork,
+    WiFiScanResult,
+    WiFiStatus,
 } from "./types.generated";
 
 // -- Frontend-only types (not part of the HTTP API) --------------------------
@@ -44,7 +47,7 @@ export interface MapRechargePoint {
     // Session-relative timestamp when the robot returned to base to charge,
     // derived from the last pose snapshot before collection paused.
     ts: number;
-    // Session-relative timestamp when cleaning resumed after the charge —
+    // Session-relative timestamp when cleaning resumed after the charge -
     // taken from the first pose snapshot written once collection restarted.
     // Falls back to `ts` when the session ended before resuming.
     endTs: number;

--- a/frontend/src/views/settings.tsx
+++ b/frontend/src/views/settings.tsx
@@ -39,6 +39,7 @@ import { SettingsCategory } from "./settings/settings-category";
 import { useFirmwareUpload } from "./settings/use-firmware-upload";
 import { useReboot } from "./settings/use-reboot";
 import { useSettingsForm } from "./settings/use-settings-form";
+import { WiFiSection } from "./settings/wifi-section";
 
 type Theme = "system" | "dark" | "light";
 
@@ -85,6 +86,8 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
         setSyslogIp,
         wifiTxPower,
         setWifiTxPower,
+        apFallbackOnDisconnect,
+        setApFallbackOnDisconnect,
         uartTxPin,
         setUartTxPin,
         uartRxPin,
@@ -491,6 +494,15 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
                             </div>
                         </button>
                     </div>
+                </SettingsCategory>
+
+                <SettingsCategory title="WiFi" icon={wifiSvg} lazy>
+                    <WiFiSection
+                        apFallbackOnDisconnect={apFallbackOnDisconnect}
+                        onApFallbackChange={setApFallbackOnDisconnect}
+                        saving={saving}
+                        errorStack={errorStack}
+                    />
                 </SettingsCategory>
 
                 <SettingsCategory title="Notifications" icon={bellSvg}>
@@ -1158,11 +1170,11 @@ export function SettingsView({ theme, onThemeChange, firmware }: SettingsViewPro
             )}
 
             {(rebooting || robotRestarting) && (
-                <div class="reboot-overlay">
-                    <div class="reboot-dialog">
-                        <div class="reboot-spinner" />
-                        <div class="reboot-text">{robotRestarting ? "Restarting robot..." : "Rebooting..."}</div>
-                        <div class="reboot-subtext">
+                <div class="loading-overlay">
+                    <div class="loading-dialog">
+                        <div class="loading-spinner" />
+                        <div class="loading-text">{robotRestarting ? "Restarting robot..." : "Rebooting..."}</div>
+                        <div class="loading-subtext">
                             {robotRestarting
                                 ? "Waiting for robot to come back online"
                                 : "Waiting for device to come back online"}

--- a/frontend/src/views/settings/constants.ts
+++ b/frontend/src/views/settings/constants.ts
@@ -115,6 +115,7 @@ export const SIDE_BRUSH_PRESETS: SideBrushPreset[] = [
 export const DEFAULT_SERVER = {
     tz: "UTC0",
     logLevel: 0,
+    apFallbackOnDisconnect: true,
     syslogEnabled: false,
     syslogIp: "",
     wifiTxPower: 60,

--- a/frontend/src/views/settings/settings-category.tsx
+++ b/frontend/src/views/settings/settings-category.tsx
@@ -7,17 +7,34 @@ interface SettingsCategoryProps {
     icon: string;
     defaultOpen?: boolean;
     disabled?: boolean;
+    // When true, children are only mounted after the section has been opened
+    // at least once. Useful for sections that poll the device or run expensive
+    // work the user shouldn't pay for unless they're looking at them.
+    lazy?: boolean;
     children: ComponentChildren;
 }
 
-export function SettingsCategory({ title, icon, defaultOpen = false, disabled, children }: SettingsCategoryProps) {
+export function SettingsCategory({
+    title,
+    icon,
+    defaultOpen = false,
+    disabled,
+    lazy = false,
+    children,
+}: SettingsCategoryProps) {
     const [open, setOpen] = useState(defaultOpen);
+    const [hasOpened, setHasOpened] = useState(defaultOpen);
+    const showChildren = lazy ? hasOpened : true;
     return (
         <div class={`settings-category${open && !disabled ? " open" : ""}${disabled ? " disabled" : ""}`}>
             <button
                 type="button"
                 class="settings-category-header"
-                onClick={() => !disabled && setOpen(!open)}
+                onClick={() => {
+                    if (disabled) return;
+                    setOpen(!open);
+                    if (!open) setHasOpened(true);
+                }}
                 disabled={disabled}
             >
                 <div class="settings-category-title">
@@ -27,7 +44,7 @@ export function SettingsCategory({ title, icon, defaultOpen = false, disabled, c
                 {!disabled && <span class="settings-category-chevron">&rsaquo;</span>}
             </button>
             <div class="settings-category-body">
-                <div class="settings-category-inner">{children}</div>
+                <div class="settings-category-inner">{showChildren && children}</div>
             </div>
         </div>
     );

--- a/frontend/src/views/settings/use-settings-form.ts
+++ b/frontend/src/views/settings/use-settings-form.ts
@@ -10,6 +10,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     // Local form state
     const [tz, setTz] = useState<string>("UTC0");
     const [logLevel, setLogLevel] = useState(0);
+    const [apFallbackOnDisconnect, setApFallbackOnDisconnect] = useState(true);
     const [syslogEnabled, setSyslogEnabled] = useState(false);
     const [syslogIp, setSyslogIp] = useState("");
     const [wifiTxPower, setWifiTxPower] = useState(60);
@@ -45,6 +46,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
             server.current = { ...fetched };
             setTz(fetched.tz);
             setLogLevel(fetched.logLevel);
+            setApFallbackOnDisconnect(fetched.apFallbackOnDisconnect ?? true);
             setSyslogEnabled(fetched.syslogEnabled ?? false);
             setSyslogIp(fetched.syslogIp ?? "");
             setWifiTxPower(fetched.wifiTxPower);
@@ -73,6 +75,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         settingsLoaded &&
         (tz !== server.current.tz ||
             logLevel !== server.current.logLevel ||
+            apFallbackOnDisconnect !== (server.current.apFallbackOnDisconnect ?? true) ||
             syslogEnabled !== (server.current.syslogEnabled ?? false) ||
             syslogIp !== (server.current.syslogIp ?? "") ||
             wifiTxPower !== server.current.wifiTxPower ||
@@ -130,6 +133,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         const patch: Partial<SettingsData> = {};
         if (tz !== server.current.tz) patch.tz = tz;
         if (logLevel !== server.current.logLevel) patch.logLevel = logLevel;
+        if (apFallbackOnDisconnect !== (server.current.apFallbackOnDisconnect ?? true))
+            patch.apFallbackOnDisconnect = apFallbackOnDisconnect;
         if (syslogEnabled !== (server.current.syslogEnabled ?? false)) patch.syslogEnabled = syslogEnabled;
         if (syslogIp !== (server.current.syslogIp ?? "")) patch.syslogIp = syslogIp;
         if (wifiTxPower !== server.current.wifiTxPower) patch.wifiTxPower = wifiTxPower;
@@ -151,6 +156,7 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
     }, [
         tz,
         logLevel,
+        apFallbackOnDisconnect,
         syslogEnabled,
         syslogIp,
         wifiTxPower,
@@ -209,6 +215,8 @@ export function useSettingsForm(errorStack: ErrorStackHandle, startRebootFlow: (
         setTz,
         logLevel,
         setLogLevel,
+        apFallbackOnDisconnect,
+        setApFallbackOnDisconnect,
         syslogEnabled,
         setSyslogEnabled,
         syslogIp,

--- a/frontend/src/views/settings/wifi-section.tsx
+++ b/frontend/src/views/settings/wifi-section.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useState } from "preact/hooks";
+import { api } from "../../api";
+import alertSvg from "../../assets/icons/alert.svg?raw";
+import bolt from "../../assets/icons/bolt.svg?raw";
+import globeSvg from "../../assets/icons/globe.svg?raw";
+import wifiSvg from "../../assets/icons/wifi.svg?raw";
+import wifiOffSvg from "../../assets/icons/wifi-off.svg?raw";
+import { ConfirmDialog } from "../../components/confirm-dialog";
+import type { ErrorStackHandle } from "../../components/error-banner";
+import { Icon } from "../../components/icon";
+import { usePolling } from "../../hooks/use-polling";
+import type { WiFiNetwork, WiFiStatus } from "../../types";
+import { normalizeError } from "../../utils";
+
+interface WiFiSectionProps {
+    apFallbackOnDisconnect: boolean;
+    onApFallbackChange: (value: boolean) => void;
+    saving: boolean;
+    errorStack: ErrorStackHandle;
+}
+
+// Map dBm to a coarse 1-4 bar count, mirroring desktop OS conventions.
+function rssiBars(rssi: number): number {
+    if (rssi >= -55) return 4;
+    if (rssi >= -65) return 3;
+    if (rssi >= -75) return 2;
+    return 1;
+}
+
+export function WiFiSection({ apFallbackOnDisconnect, onApFallbackChange, saving, errorStack }: WiFiSectionProps) {
+    const statusPoll = usePolling<WiFiStatus>(api.getWifiStatus, 5000);
+    const status = statusPoll.data;
+
+    const [scanning, setScanning] = useState(false);
+    const [networks, setNetworks] = useState<WiFiNetwork[] | null>(null);
+    const [selectedSsid, setSelectedSsid] = useState("");
+    const [pendingNetwork, setPendingNetwork] = useState<WiFiNetwork | null>(null);
+    const [connecting, setConnecting] = useState(false);
+    const [disconnecting, setDisconnecting] = useState(false);
+    const [showForgetConfirm, setShowForgetConfirm] = useState(false);
+
+    const handleScan = useCallback(() => {
+        setScanning(true);
+        api.scanWifi()
+            .then((res) => {
+                // Sort strongest first; deduplicate by SSID (keep best RSSI per name)
+                const best = new Map<string, WiFiNetwork>();
+                for (const n of res.networks) {
+                    if (!n.ssid) continue;
+                    const existing = best.get(n.ssid);
+                    if (!existing || n.rssi > existing.rssi) best.set(n.ssid, n);
+                }
+                setNetworks([...best.values()].sort((a, b) => b.rssi - a.rssi));
+            })
+            .catch((e: unknown) => errorStack.push(normalizeError(e, "WiFi scan failed")))
+            .finally(() => setScanning(false));
+    }, [errorStack]);
+
+    const startConnect = useCallback(
+        (ssid: string) => {
+            const network = networks?.find((n) => n.ssid === ssid);
+            if (!network) return;
+            setPendingNetwork(network);
+        },
+        [networks],
+    );
+
+    // Drop the connect dialog and reset the dropdown back to "Choose a
+    // network". Used on cancel and on connect failure so the UI is in the
+    // same clean state either way.
+    const resetConnectFlow = useCallback(() => {
+        setPendingNetwork(null);
+        setSelectedSsid("");
+    }, []);
+
+    const handleConnectConfirm = useCallback(
+        (password?: string) => {
+            const network = pendingNetwork;
+            if (!network) return;
+            setConnecting(true);
+            api.connectWifi(network.ssid, password ?? "")
+                .then(() => {
+                    // Reload so the settings page picks up the new STA state
+                    // and the connecting overlay clears. On real hardware the
+                    // device reboots and the browser was on the AP, so the
+                    // reload also forces a fresh navigation to the new IP.
+                    window.location.reload();
+                })
+                .catch((e: unknown) => {
+                    errorStack.push(normalizeError(e, "Failed to connect"));
+                    resetConnectFlow();
+                    setConnecting(false);
+                });
+        },
+        [pendingNetwork, errorStack, resetConnectFlow],
+    );
+
+    const handleForget = useCallback(() => {
+        setShowForgetConfirm(false);
+        setDisconnecting(true);
+        api.disconnectWifi()
+            .then(() => {
+                // Reload so the page reflects the post-disconnect state
+                // (no current network, fallback AP active) without keeping
+                // stale local UI state around.
+                window.location.reload();
+            })
+            .catch((e: unknown) => {
+                errorStack.push(normalizeError(e, "Failed to forget network"));
+                setDisconnecting(false);
+            });
+    }, [errorStack]);
+
+    const busy = scanning || connecting || disconnecting;
+
+    return (
+        <>
+            <div class="settings-section">
+                <div class="settings-section-title">Status</div>
+                <div class="fw-info-row">
+                    <div class="fw-info-item">
+                        <Icon svg={status?.staConnected ? wifiSvg : wifiOffSvg} />
+                        <span>
+                            {status
+                                ? status.staConnected
+                                    ? `${status.ssid || "Connected"}`
+                                    : status.ssid
+                                      ? `Disconnected (${status.ssid})`
+                                      : "Not configured"
+                                : "..."}
+                        </span>
+                    </div>
+                    {status?.staConnected && (
+                        <>
+                            <div class="fw-info-item">
+                                <Icon svg={globeSvg} />
+                                <span>{status.ip}</span>
+                            </div>
+                            <div class="fw-info-item">
+                                <Icon svg={bolt} />
+                                <span>
+                                    {status.rssi} dBm ({rssiBars(status.rssi)}/4)
+                                </span>
+                            </div>
+                        </>
+                    )}
+                    {status?.apActive && (
+                        <div class="fw-info-item">
+                            <Icon svg={wifiSvg} />
+                            <span>
+                                AP: {status.apSsid} @ {status.apIp}
+                                {status.apClients > 0 && ` (${status.apClients})`}
+                            </span>
+                        </div>
+                    )}
+                </div>
+                {status && !status.staConnected && status.lastError && (
+                    <div class="settings-field-error">{status.lastError}</div>
+                )}
+            </div>
+
+            <div class="settings-section">
+                <div class="settings-toggle-row">
+                    <div class="settings-toggle-label">
+                        <span class="settings-toggle-title">Fallback AP on disconnect</span>
+                        <span class="settings-toggle-desc">
+                            Expose <code>{`<hostname>-ap`}</code> when the saved network is unreachable so you can
+                            recover from a browser. Always on when no credentials are saved.
+                        </span>
+                    </div>
+                    <button
+                        type="button"
+                        class={`settings-toggle${apFallbackOnDisconnect ? " on" : ""}`}
+                        onClick={() => onApFallbackChange(!apFallbackOnDisconnect)}
+                        disabled={saving}
+                        aria-label="Toggle fallback AP"
+                    />
+                </div>
+            </div>
+
+            <div class="settings-section">
+                <div class="settings-section-title">Connect to a network</div>
+                <div class="settings-wifi-pick-row">
+                    <div class="settings-tz-select-wrap settings-wifi-select">
+                        <select
+                            class="settings-tz-select"
+                            value={selectedSsid}
+                            onChange={(e) => {
+                                const value = (e.target as HTMLSelectElement).value;
+                                setSelectedSsid(value);
+                                if (value) startConnect(value);
+                            }}
+                            disabled={busy || !networks || networks.length === 0}
+                        >
+                            <option value="">
+                                {scanning
+                                    ? "Scanning..."
+                                    : networks
+                                      ? networks.length === 0
+                                          ? "No networks found"
+                                          : "Choose a network"
+                                      : "Scan to choose a network"}
+                            </option>
+                            {networks?.map((n) => (
+                                <option key={n.ssid} value={n.ssid}>
+                                    {n.ssid} ({n.rssi} dBm{n.open ? ", open" : ""})
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <button
+                        type="button"
+                        class={`settings-wifi-scan-btn${scanning ? " pending" : ""}`}
+                        onClick={handleScan}
+                        disabled={busy}
+                        aria-label="Scan for networks"
+                    >
+                        Scan
+                    </button>
+                </div>
+            </div>
+
+            {status?.staConnected && (
+                <div class="settings-section">
+                    <button
+                        type="button"
+                        class={`settings-nav-row danger${disconnecting ? " pending" : ""}`}
+                        onClick={() => setShowForgetConfirm(true)}
+                        disabled={busy}
+                    >
+                        <div class="settings-nav-row-left">
+                            <Icon svg={alertSvg} />
+                            {disconnecting ? "Forgetting..." : "Forget current network"}
+                        </div>
+                    </button>
+                </div>
+            )}
+
+            {pendingNetwork && !connecting && (
+                <ConfirmDialog
+                    message={
+                        pendingNetwork.open
+                            ? `Connect to ${pendingNetwork.ssid}? It is an open network.`
+                            : `Enter the password for ${pendingNetwork.ssid}.`
+                    }
+                    confirmLabel="Connect"
+                    destructive={false}
+                    inputType={pendingNetwork.open ? undefined : "password"}
+                    inputPlaceholder="Network password"
+                    inputRequired={!pendingNetwork.open}
+                    onConfirm={handleConnectConfirm}
+                    onCancel={resetConnectFlow}
+                />
+            )}
+
+            {connecting && pendingNetwork && (
+                <div class="loading-overlay">
+                    <div class="loading-dialog">
+                        <div class="loading-spinner" />
+                        <div class="loading-text">Connecting to {pendingNetwork.ssid}...</div>
+                        <div class="loading-subtext">
+                            The device will reboot after joining the network. You may need to reconnect your browser.
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {showForgetConfirm && (
+                <ConfirmDialog
+                    message={`Forget "${status?.ssid ?? "current network"}"? Saved credentials will be erased and the device will drop to the fallback AP.`}
+                    confirmLabel="Forget"
+                    onConfirm={() => handleForget()}
+                    onCancel={() => setShowForgetConfirm(false)}
+                />
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
- Fallback AP activates when STA is missing or disconnected, keeping the device reachable without cloud
- New firmware endpoints: `GET /api/wifi/status`, `GET /api/wifi/scan`, `POST /api/wifi/connect`, `POST /api/wifi/disconnect`
- WiFi section in Settings: scan, connect/disconnect, AP status
- OpenAPI spec updated with WiFi routes and schemas; `apFallbackOnDisconnect` added to `SettingsData`

Closes #84, closes #108