### PR TITLE
fix S3 flash size

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,8 @@ build_flags =
 
 [board_s3]
 board = esp32-s3-devkitc-1
+board_build.flash_size = 4MB
+board_upload.flash_size = 4MB
 build_flags =
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1


### PR DESCRIPTION
## Summary
- Build ESP32-S3 release images with a 4MB flash header

Fixes #115