### PR TITLE
feat(wifi): add mDNS responder for <hostname>.local discovery

### DIFF
--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -1,5 +1,6 @@
 #include "wifi_manager.h"
 #include "data_logger.h"
+#include <ESPmDNS.h>
 #include <esp_task_wdt.h>
 #include <esp_wifi.h>
 
@@ -56,6 +57,7 @@ void WiFiManager::begin() {
             LOG("WIFI", "Connected successfully!");
             LOG("WIFI", "IP: %s", WiFi.localIP().toString().c_str());
             LOG("WIFI", "MAC: %s", WiFi.macAddress().c_str());
+            startMdns();
 
             // Log successful boot connection with diagnostics
             dataLogger.logWifi("boot_connect", {{"ssid", ssid, FIELD_STRING},
@@ -417,6 +419,7 @@ void WiFiManager::tick() {
 
     if (WiFi.status() == WL_CONNECTED) {
         applyTxPower();
+        startMdns();
         LOG("WIFI", "Reconnected! IP: %s, RSSI: %d, attempt: %lu", WiFi.localIP().toString().c_str(), WiFi.RSSI(),
             reconnectAttemptCount);
 
@@ -517,6 +520,7 @@ void WiFiManager::startAccessPoint() {
     apActive = true;
     LOG("WIFI", "AP active: SSID=%s IP=%s", ssid.c_str(), WiFi.softAPIP().toString().c_str());
     dataLogger.logWifi("ap_start", {{"ssid", ssid, FIELD_STRING}, {"ip", WiFi.softAPIP().toString(), FIELD_STRING}});
+    startMdns();
 }
 
 void WiFiManager::stopAccessPoint() {
@@ -530,6 +534,18 @@ void WiFiManager::stopAccessPoint() {
     WiFi.mode(WIFI_STA);
     apActive = false;
     dataLogger.logWifi("ap_stop");
+}
+
+void WiFiManager::startMdns() {
+    // ESPmDNS rebinds cleanly when called again after an interface change
+    // (e.g. AP went up while STA was still associating). Safe to call from
+    // both AP and STA bring-up paths.
+    if (MDNS.begin(hostname.c_str())) {
+        MDNS.addService("http", "tcp", 80);
+        LOG("WIFI", "mDNS responder up: %s.local", hostname.c_str());
+    } else {
+        LOG("WIFI", "mDNS init failed");
+    }
 }
 
 void WiFiManager::reevaluateFallbackAp() {

--- a/firmware/src/wifi_manager.h
+++ b/firmware/src/wifi_manager.h
@@ -131,6 +131,11 @@ private:
     // Called whenever STA state, credentials, or apFallbackOnDisconnect change.
     void reevaluateFallbackAp();
 
+    // Idempotent: bring up the mDNS responder for <hostname>.local advertising
+    // the web UI on port 80. Called whenever a network interface (STA or AP)
+    // becomes available so clients can reach the device without knowing its IP.
+    void startMdns();
+
     // Menu actions
     void scanNetworksMenu();
     void manualSSID();


### PR DESCRIPTION
## Summary

- Add `startMdns()` invoked from boot, reconnect, and softAP start paths
- Advertise the web UI as `_http._tcp` on port 80 from `<hostname>.local`
- Works on both the STA subnet and the fallback AP subnet — no IP lookup needed

## Context

`wifi_manager.h:82` mentions mDNS in a comment ("Set hostname for WiFi/mDNS"),
but no responder was ever started. Only `WiFi.setHostname()` was called,
which sets the DHCP hostname — that's router-dependent and commonly blocked
by consumer ISP boxes (Freebox, SFR, Livebox), so `neato.local` never
resolved in practice.

This patch starts `MDNS.begin(hostname)` + `MDNS.addService("http","tcp",80)`
on every network-bringup transition, idempotent across STA/AP changes.

## Verified

- Compile clean: `pio run -e s3-release`
- clang-format clean: `./scripts/check_format.py`
- Hardware: ESP32-S3 reachable as `<hostname>.local` from macOS, Windows
  and iOS — both on the STA network and on the fallback AP subnet
  (resolves to 192.168.4.1 when joined to `<hostname>-ap`).

## Notes

- ESPmDNS is part of the Arduino-ESP32 framework — no new `lib_deps`.
- Android natively does not resolve `.local`; users still need a Bonjour
  app or the raw IP. This is an OS limitation, not addressable in firmware.