### PR TITLE
Add ESP32-C5 support

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -36,6 +36,11 @@
 #define NEATO_DEFAULT_TX_PIN 3
 #define NEATO_DEFAULT_RX_PIN 4
 #define MAX_GPIO_PIN 21
+#elif CONFIG_IDF_TARGET_ESP32C5
+#define RESET_BUTTON_PIN -1 // Disabled for C5: GPIO9 may be a boot/strap pin and can wipe NVS if read low
+#define NEATO_DEFAULT_TX_PIN 11
+#define NEATO_DEFAULT_RX_PIN 12
+#define MAX_GPIO_PIN 28
 #elif CONFIG_IDF_TARGET_ESP32S3
 #define RESET_BUTTON_PIN 0
 #define NEATO_DEFAULT_TX_PIN 17

--- a/firmware/src/firmware_manager.cpp
+++ b/firmware/src/firmware_manager.cpp
@@ -21,6 +21,7 @@ bool FirmwareManager::validateChip(uint8_t *data, size_t len) {
             {0x02, CHIP_ESP32S2},
             {0x05, CHIP_ESP32C3},
             {0x09, CHIP_ESP32S3},
+            {0x17, 23}, // ESP32-C5 (CHIP_ESP32C5 in ESP-IDF 5.5+)
     };
     auto binChipId = static_cast<uint8_t>(data[12]);
     const ChipMap *match = nullptr;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -46,8 +46,10 @@ void setup() {
     // Open shared NVS namespace (stays open for the lifetime of the device)
     prefs.begin(NVS_NAMESPACE, false);
 
-    // Setup reset button
-    pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
+    // Setup reset button when the board definition provides one.
+    if (RESET_BUTTON_PIN >= 0) {
+        pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
+    }
 
     // Initialize settings first (loads pin config from NVS before UART init)
     LOG("BOOT", "Initializing settings...");
@@ -225,7 +227,7 @@ void loop() {
     static unsigned long buttonPressStart = 0;
     static bool buttonWasPressed = false;
 
-    if (digitalRead(RESET_BUTTON_PIN) == LOW) {
+    if (RESET_BUTTON_PIN >= 0 && digitalRead(RESET_BUTTON_PIN) == LOW) {
         if (!buttonWasPressed) {
             // Button just pressed
             buttonPressStart = millis();

--- a/firmware/src/system_manager.cpp
+++ b/firmware/src/system_manager.cpp
@@ -2,6 +2,7 @@
 #include <SPIFFS.h>
 #include <WiFi.h>
 #include <ctime>
+#include <esp_idf_version.h>
 
 SystemManager::SystemManager(Preferences& prefs) : LoopTask(5000), prefs(prefs) {
     TaskRegistry::add(this);
@@ -19,7 +20,12 @@ void SystemManager::begin() {
 void SystemManager::initTaskWdt() {
     // Initialize TWDT with configured timeout. If loop() stops calling
     // feedTaskWdt(), the hardware watchdog resets the ESP32.
+#if ESP_IDF_VERSION_MAJOR >= 5
+    const esp_task_wdt_config_t twdtConfig = {TASK_WDT_TIMEOUT_S * 1000, 0, true};
+    esp_task_wdt_init(&twdtConfig);
+#else
     esp_task_wdt_init(TASK_WDT_TIMEOUT_S, true); // true = panic (reset) on timeout
+#endif
     esp_task_wdt_add(nullptr); // nullptr = subscribe current task (loopTask)
     LOG("SYS", "Task watchdog initialized (%ds timeout)", TASK_WDT_TIMEOUT_S);
 }

--- a/frontend/scripts/embed_frontend.js
+++ b/frontend/scripts/embed_frontend.js
@@ -14,6 +14,20 @@ import zlib from "node:zlib";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distDir = path.join(__dirname, "..", "dist");
 const outHeader = path.join(__dirname, "..", "..", "firmware", "src", "web_assets.h");
+const skipAssets = (process.env.OPENNEATO_SKIP_WEB_ASSETS || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+function shouldSkipAsset(relPath) {
+    const normalized = relPath.split(path.sep).join("/");
+    return skipAssets.some((pattern) => {
+        if (pattern.startsWith("*.")) {
+            return normalized.endsWith(pattern.slice(1));
+        }
+        return normalized === pattern || `/${normalized}` === pattern;
+    });
+}
 
 // MIME type lookup by extension (keep minimal, expand as needed)
 const mimeTypes = {
@@ -77,6 +91,15 @@ if (relPaths.length === 0) {
     process.exit(1);
 }
 
+const embeddedRelPaths = relPaths.filter((relPath) => !shouldSkipAsset(relPath));
+if (skipAssets.length > 0) {
+    console.log(`Skipping web assets matching: ${skipAssets.join(", ")}`);
+}
+if (embeddedRelPaths.length === 0) {
+    console.error("No files left to embed after OPENNEATO_SKIP_WEB_ASSETS filtering");
+    process.exit(1);
+}
+
 let header = `#ifndef WEB_ASSETS_H
 #define WEB_ASSETS_H
 
@@ -96,7 +119,7 @@ struct WebAsset {
 
 const assetEntries = [];
 
-for (const relPath of relPaths) {
+for (const relPath of embeddedRelPaths) {
     const filePath = path.join(distDir, relPath);
     const raw = fs.readFileSync(filePath);
     const gzipped = zlib.gzipSync(raw, { level: 9 });

--- a/frontend/src/views/settings/use-firmware-upload.ts
+++ b/frontend/src/views/settings/use-firmware-upload.ts
@@ -22,6 +22,7 @@ const CHIP_IDS: Record<number, string> = {
     12: "ESP32-C2",
     13: "ESP32-C6",
     16: "ESP32-H2",
+    23: "ESP32-C5",
 };
 
 function parseChipFromBin(buf: ArrayBuffer): string | null {

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ lib_dir = firmware/lib
 ; --- Shared across all boards and modes ---------------------------------------
 
 [env]
-platform = espressif32 @ 7.0.1
+platform = espressif32 @ 55.3.38
 framework = arduino
 extra_scripts = pre:scripts/env_config.py
 board_build.partitions = firmware/partition.csv
@@ -72,6 +72,36 @@ build_flags =
 extends = board_c3
 build_flags =
     ${board_c3.build_flags}
+    -DENABLE_LOGGING=0
+
+; --- Board: ESP32-C5-DevKitC-1 (WiFi 6 2.4/5 GHz) ---------------------------
+
+[board_c5]
+board = esp32-c5-devkitc-1
+board_build.flash_size = 4MB
+board_upload.flash_size = 4MB
+build_flags =
+    -Wno-attributes
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DCHIP_MODEL=\"ESP32-C5\"
+    -std=gnu++17
+
+; --- Targets (C5) ------------------------------------------------------------
+
+[env:c5-debug]
+extends = board_c5
+
+[env:c5-ota]
+extends = board_c5, mode_ota
+build_flags =
+    ${board_c5.build_flags}
+    -DENABLE_LOGGING=0
+
+[env:c5-release]
+extends = board_c5
+build_flags =
+    ${board_c5.build_flags}
     -DENABLE_LOGGING=0
 
 ; --- Board: ESP32-S3-DevKitC-1 (Xtensa LX7, dual-core, native USB) -----------


### PR DESCRIPTION
## Summary

- upgrade PlatformIO Espressif32 platform to 55.3.38 so ESP32-C5 boards are available from the registry
- add ESP32-C5 build environments and default UART pins
- disable reset-button handling on ESP32-C5 because GPIO9 can be unsafe as a runtime reset input
- support ESP-IDF 5 task watchdog initialization
- recognize ESP32-C5 OTA images in backend and frontend firmware validators
- add optional frontend asset skipping hook for size-constrained builds

## Validation

Built all release targets successfully:

- `pio run -e c3-release -e c5-release -e s3-release -e esp32-release`

Result: 4 succeeded.

Also tested C5 release build with registry-pinned `espressif32 @ 55.3.38` and generated ESP32-C5 release artifacts successfully.