### PR TITLE
fix: pause reconnect in recovery AP

### DIFF
--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -395,6 +395,11 @@ void WiFiManager::tick() {
     if (inConfigMode || !wasConnected || WiFi.status() == WL_CONNECTED)
         return;
 
+    if (apActive && WiFi.softAPgetStationNum() > 0) {
+        LOG("WIFI", "Reconnect paused while fallback AP has clients");
+        return;
+    }
+
     reconnectAttemptCount++;
     LOG("WIFI", "Connection lost — reconnecting (attempt %lu, backoff %lu ms)...", reconnectAttemptCount,
         reconnectBackoff);


### PR DESCRIPTION
- Pause saved Wi-Fi reconnect while recovery AP has clients

Fixes #134