### PR TITLE
feat: add cleaning statistics view with weekly chart

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -11,6 +11,7 @@ import { LogsView } from "./views/logs";
 import { ManualView } from "./views/manual";
 import { ScheduleView } from "./views/schedule";
 import { SettingsView } from "./views/settings";
+import { StatsView } from "./views/stats";
 
 type Theme = "system" | "dark" | "light";
 
@@ -181,6 +182,9 @@ export function App() {
             </Route>
             <Route path="/history" prefix>
                 <HistoryView />
+            </Route>
+            <Route path="/stats">
+                <StatsView />
             </Route>
         </Router>
     );

--- a/frontend/src/assets/icons/chart.svg
+++ b/frontend/src/assets/icons/chart.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="13" width="4" height="8" rx="1"/>
+  <rect x="10" y="8" width="4" height="13" rx="1"/>
+  <rect x="17" y="4" width="4" height="17" rx="1"/>
+</svg>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3250,6 +3250,62 @@ input:disabled {
     opacity: 0.85;
 }
 
+.stats-chart-area {
+    fill: url(#stats-area-grad);
+}
+
+.stats-chart-line {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.stats-area-grad-top {
+    stop-color: var(--accent);
+    stop-opacity: 0.35;
+}
+
+.stats-area-grad-bottom {
+    stop-color: var(--accent);
+    stop-opacity: 0;
+}
+
+.stats-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}
+
+.stats-section-header .stats-section-title {
+    margin-bottom: 0;
+}
+
+.stats-year-picker {
+    display: flex;
+    gap: 4px;
+}
+
+.stats-year-btn {
+    padding: 2px 8px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.stats-year-btn.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
 .stats-chart-label {
     fill: var(--text-dim);
     font-size: 9px;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3297,7 +3297,9 @@ input:disabled {
     font-size: 11px;
     font-family: inherit;
     cursor: pointer;
-    transition: background 0.15s, color 0.15s;
+    transition:
+        background 0.15s,
+        color 0.15s;
 }
 
 .stats-year-btn.active {
@@ -3357,7 +3359,10 @@ input:disabled {
     font-size: 11px;
     font-family: inherit;
     cursor: pointer;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    transition:
+        background 0.15s,
+        color 0.15s,
+        border-color 0.15s;
 }
 
 .stats-metric-btn.active {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3312,6 +3312,80 @@ input:disabled {
     font-family: inherit;
 }
 
+.stats-chart-label-sel {
+    fill: var(--accent);
+}
+
+.stats-chart-selector {
+    stroke: var(--accent);
+    stroke-width: 1;
+    stroke-dasharray: 3 3;
+    opacity: 0.6;
+}
+
+.stats-chart-dot {
+    fill: var(--accent);
+    stroke: var(--surface);
+    stroke-width: 1.5;
+}
+
+.stats-chart-tooltip-bg {
+    fill: var(--surface-raised);
+    stroke: var(--border);
+    stroke-width: 0.5;
+}
+
+.stats-chart-tooltip-text {
+    fill: var(--text);
+    font-size: 9px;
+    font-family: inherit;
+}
+
+.stats-metric-picker {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+
+.stats-metric-btn {
+    flex: 1;
+    padding: 4px 6px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-dim);
+    font-size: 11px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.stats-metric-btn.active {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.stats-year-nav {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.stats-year-nav-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-dim);
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+}
+
+.stats-year-nav-btn:disabled {
+    color: var(--border);
+    cursor: default;
+}
+
 .stats-chart-unit {
     font-size: 11px;
     color: var(--text-muted);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3162,3 +3162,145 @@ input:disabled {
         font-size: 28px;
     }
 }
+
+/* -- Statistics view --------------------------------------------------- */
+
+.stats-page {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    overflow-y: auto;
+}
+
+.stats-empty {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--text-dim);
+    font-size: 14px;
+}
+
+.stats-totals {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+.stats-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px 16px;
+}
+
+.stats-card-label {
+    font-size: 11px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.stats-card-value {
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--text);
+    margin-top: 4px;
+    line-height: 1.1;
+}
+
+.stats-card-unit {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--text-dim);
+}
+
+.stats-section {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px 16px;
+}
+
+.stats-section-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 12px;
+}
+
+.stats-chart {
+    display: block;
+    overflow: visible;
+}
+
+.stats-chart-grid {
+    stroke: var(--border);
+    stroke-width: 1;
+}
+
+.stats-chart-baseline {
+    stroke: var(--text-muted);
+    stroke-width: 1;
+}
+
+.stats-chart-bar {
+    fill: var(--accent);
+    opacity: 0.85;
+}
+
+.stats-chart-label {
+    fill: var(--text-dim);
+    font-size: 9px;
+    font-family: inherit;
+}
+
+.stats-chart-unit {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-align: right;
+    margin-top: 4px;
+}
+
+.stats-modes {
+    display: flex;
+    gap: 10px;
+}
+
+.stats-mode-pill {
+    flex: 1;
+    text-align: center;
+    padding: 10px 8px;
+    background: var(--surface-raised);
+    border-radius: 8px;
+}
+
+.stats-mode-count {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.stats-mode-label {
+    font-size: 11px;
+    color: var(--text-dim);
+    margin-top: 2px;
+}
+
+.stats-battery-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+}
+
+.stats-battery-row .stats-section-title {
+    margin-bottom: 0;
+}
+
+.stats-battery-value {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--amber);
+}

--- a/frontend/src/views/history.tsx
+++ b/frontend/src/views/history.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import { api, ResponseParseError } from "../api";
 import backSvg from "../assets/icons/back.svg?raw";
+import chartSvg from "../assets/icons/chart.svg?raw";
 import { ConfirmDialog } from "../components/confirm-dialog";
 import { ErrorBannerStack, useErrorStack } from "../components/error-banner";
 import { Icon } from "../components/icon";
@@ -167,7 +168,18 @@ export function HistoryView() {
                     <Icon svg={backSvg} />
                 </button>
                 <h1>{showDetail ? "Clean Map" : "Cleaning History"}</h1>
-                <div class="header-right-spacer" />
+                {!showDetail && !listCorrupted ? (
+                    <button
+                        type="button"
+                        class="header-right-btn"
+                        aria-label="Statistics"
+                        onClick={() => navigate("/stats")}
+                    >
+                        <Icon svg={chartSvg} />
+                    </button>
+                ) : (
+                    <div class="header-right-spacer" />
+                )}
             </div>
 
             <ErrorBannerStack errors={errors} />

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -54,7 +54,7 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
         totalDistance += s.distanceTraveled;
         totalDuration += s.duration;
         const battStart = s.batteryStart ?? f.session?.battery;
-        if (battStart != null && s.batteryEnd != null) {
+        if (battStart != null && s.batteryEnd != null && battStart > s.batteryEnd) {
             batterySum += battStart - s.batteryEnd;
             batteryCount++;
         }

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -191,7 +191,7 @@ export function StatsView() {
     return (
         <>
             <div class="header">
-                <button type="button" class="header-back-btn" onClick={() => navigate("/")} aria-label="Back">
+                <button type="button" class="header-back-btn" onClick={() => navigate("/history")} aria-label="Back">
                     <Icon svg={backSvg} />
                 </button>
                 <h1>Statistics</h1>

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -245,9 +245,7 @@ function MonthlyChart({
             {line && <path d={line} class="stats-chart-line" />}
 
             {/* Selected month vertical line */}
-            {tooltip && (
-                <line x1={tooltip.x} y1={PT} x2={tooltip.x} y2={baseline} class="stats-chart-selector" />
-            )}
+            {tooltip && <line x1={tooltip.x} y1={PT} x2={tooltip.x} y2={baseline} class="stats-chart-selector" />}
 
             {/* X-axis month labels */}
             {MONTH_LABELS.map((label, i) => (
@@ -265,8 +263,9 @@ function MonthlyChart({
             {/* Baseline */}
             <line x1={PL} y1={baseline} x2={CW - PR} y2={baseline} class="stats-chart-baseline" />
 
-            {/* Click zones */}
+            {/* Click zones — SVG is aria-hidden so no role needed */}
             {MONTH_LABELS.map((_, i) => (
+                // biome-ignore lint/a11y/noStaticElementInteractions: chart is aria-hidden
                 <rect
                     key={i}
                     x={PL + i * slotW}
@@ -381,31 +380,32 @@ export function StatsView() {
                                 <div class="stats-section-title">
                                     {METRIC_TITLES[selectedMetric]} · {selectedYear}
                                 </div>
-                                {stats.availableYears.length > 1 && (() => {
-                                    const idx = stats.availableYears.indexOf(selectedYear);
-                                    return (
-                                        <div class="stats-year-nav">
-                                            <button
-                                                type="button"
-                                                class="stats-year-nav-btn"
-                                                disabled={idx >= stats.availableYears.length - 1}
-                                                onClick={() => setSelectedYear(stats.availableYears[idx + 1])}
-                                                aria-label="Previous year"
-                                            >
-                                                ‹
-                                            </button>
-                                            <button
-                                                type="button"
-                                                class="stats-year-nav-btn"
-                                                disabled={idx <= 0}
-                                                onClick={() => setSelectedYear(stats.availableYears[idx - 1])}
-                                                aria-label="Next year"
-                                            >
-                                                ›
-                                            </button>
-                                        </div>
-                                    );
-                                })()}
+                                {stats.availableYears.length > 1 &&
+                                    (() => {
+                                        const idx = stats.availableYears.indexOf(selectedYear);
+                                        return (
+                                            <div class="stats-year-nav">
+                                                <button
+                                                    type="button"
+                                                    class="stats-year-nav-btn"
+                                                    disabled={idx >= stats.availableYears.length - 1}
+                                                    onClick={() => setSelectedYear(stats.availableYears[idx + 1])}
+                                                    aria-label="Previous year"
+                                                >
+                                                    ‹
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    class="stats-year-nav-btn"
+                                                    disabled={idx <= 0}
+                                                    onClick={() => setSelectedYear(stats.availableYears[idx - 1])}
+                                                    aria-label="Next year"
+                                                >
+                                                    ›
+                                                </button>
+                                            </div>
+                                        );
+                                    })()}
                             </div>
                             <div class="stats-metric-picker">
                                 {METRICS.map(({ key, label }) => (

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -9,6 +9,43 @@ import { formatDuration } from "./history/helpers";
 
 const MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
+type ChartMetric = "area" | "distance" | "duration" | "cleans";
+
+const METRICS: { key: ChartMetric; label: string }[] = [
+    { key: "area", label: "Area" },
+    { key: "distance", label: "Distance" },
+    { key: "duration", label: "Runtime" },
+    { key: "cleans", label: "Cleans" },
+];
+
+const METRIC_TITLES: Record<ChartMetric, string> = {
+    area: "Area covered",
+    distance: "Distance",
+    duration: "Runtime",
+    cleans: "Cleans",
+};
+
+const METRIC_UNITS: Record<ChartMetric, string> = {
+    area: "m²",
+    distance: "m",
+    duration: "",
+    cleans: "",
+};
+
+interface MonthlyData {
+    area: number[];
+    distance: number[];
+    duration: number[];
+    cleans: number[];
+}
+
+const EMPTY_MONTHLY: MonthlyData = {
+    area: Array(12).fill(0),
+    distance: Array(12).fill(0),
+    duration: Array(12).fill(0),
+    cleans: Array(12).fill(0),
+};
+
 interface StatsData {
     totalCleans: number;
     totalArea: number;
@@ -16,7 +53,7 @@ interface StatsData {
     totalDuration: number;
     avgBatteryUsed: number | null;
     availableYears: number[];
-    monthlyByYear: Record<number, number[]>;
+    monthlyByYear: Record<number, MonthlyData>;
     modeCounts: { house: number; spot: number; manual: number };
 }
 
@@ -29,7 +66,7 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
     let batterySum = 0;
     let batteryCount = 0;
     const modeCounts = { house: 0, spot: 0, manual: 0 };
-    const monthlyByYear: Record<number, number[]> = {};
+    const monthlyByYear: Record<number, MonthlyData> = {};
 
     for (const f of finished) {
         if (!f.summary) continue;
@@ -47,13 +84,21 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
         else if (mode === "spot") modeCounts.spot++;
         else modeCounts.manual++;
 
-        if (f.session) {
-            const d = new Date(f.session.time * 1000);
-            const year = d.getUTCFullYear();
-            const month = d.getUTCMonth();
-            if (!monthlyByYear[year]) monthlyByYear[year] = Array(12).fill(0);
-            monthlyByYear[year][month] += s.areaCovered;
-        }
+        const sessionTime = f.session?.time ?? s.time;
+        const d = new Date(sessionTime * 1000);
+        const year = d.getFullYear();
+        const month = d.getMonth();
+        if (!monthlyByYear[year])
+            monthlyByYear[year] = {
+                area: Array(12).fill(0),
+                distance: Array(12).fill(0),
+                duration: Array(12).fill(0),
+                cleans: Array(12).fill(0),
+            };
+        monthlyByYear[year].area[month] += s.areaCovered;
+        monthlyByYear[year].distance[month] += s.distanceTraveled;
+        monthlyByYear[year].duration[month] += s.duration;
+        monthlyByYear[year].cleans[month]++;
     }
 
     const availableYears = Object.keys(monthlyByYear)
@@ -75,6 +120,35 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
 function formatDistance(m: number): { value: string; unit: string } {
     if (m >= 1000) return { value: (m / 1000).toFixed(1), unit: "km" };
     return { value: m.toFixed(0), unit: "m" };
+}
+
+function metricAxisLabel(val: number, metric: ChartMetric): string {
+    switch (metric) {
+        case "area":
+            return val.toFixed(1);
+        case "distance":
+            return val >= 1000 ? `${(val / 1000).toFixed(1)}k` : val.toFixed(0);
+        case "duration": {
+            const h = Math.floor(val / 3600);
+            const m = Math.floor((val % 3600) / 60);
+            return h > 0 ? `${h}h${m}m` : `${m}m`;
+        }
+        case "cleans":
+            return String(Math.round(val));
+    }
+}
+
+function formatMetricVal(val: number, metric: ChartMetric): string {
+    switch (metric) {
+        case "area":
+            return `${val.toFixed(1)} m²`;
+        case "distance":
+            return val >= 1000 ? `${(val / 1000).toFixed(1)} km` : `${val.toFixed(0)} m`;
+        case "duration":
+            return formatDuration(Math.round(val));
+        case "cleans":
+            return `${Math.round(val)}`;
+    }
 }
 
 // -- Chart ---------------------------------------------------------------
@@ -100,9 +174,9 @@ function smoothPaths(points: [number, number][], baseline: number): { area: stri
         const p3 = points[Math.min(points.length - 1, i + 2)];
 
         const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
-        const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
+        const cp1y = Math.max(PT, Math.min(baseline, p1[1] + (p2[1] - p0[1]) / 6));
         const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
-        const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
+        const cp2y = Math.max(PT, Math.min(baseline, p2[1] - (p3[1] - p1[1]) / 6));
 
         line += ` C ${cp1x.toFixed(2)} ${cp1y.toFixed(2)},${cp2x.toFixed(2)} ${cp2y.toFixed(2)},${p2[0].toFixed(2)} ${p2[1].toFixed(2)}`;
     }
@@ -114,15 +188,36 @@ function smoothPaths(points: [number, number][], baseline: number): { area: stri
     return { area, line };
 }
 
-function MonthlyChart({ data }: { data: number[] }) {
-    const maxArea = Math.max(...data, 0.01);
+function MonthlyChart({
+    data,
+    metric,
+    selectedMonth,
+    onSelectMonth,
+}: {
+    data: number[];
+    metric: ChartMetric;
+    selectedMonth: number | null;
+    onSelectMonth: (m: number | null) => void;
+}) {
+    const maxVal = Math.max(...data, 0.01);
     const slotW = CHART_W / 12;
     const baseline = PT + CHART_H;
-
-    const toY = (area: number) => PT + CHART_H * (1 - area / maxArea);
-
-    const points: [number, number][] = data.map((area, i) => [PL + i * slotW + slotW / 2, toY(area)]);
+    const toY = (v: number) => PT + CHART_H * (1 - v / maxVal);
+    const points: [number, number][] = data.map((v, i) => [PL + i * slotW + slotW / 2, toY(v)]);
     const { area, line } = smoothPaths(points, baseline);
+
+    const tooltip =
+        selectedMonth !== null
+            ? (() => {
+                  const x = points[selectedMonth][0];
+                  const y = points[selectedMonth][1];
+                  const label = `${MONTH_LABELS[selectedMonth]}: ${formatMetricVal(data[selectedMonth], metric)}`;
+                  const tw = label.length * 5.2 + 10;
+                  const tx = Math.max(PL + 2, Math.min(CW - PR - tw - 2, x - tw / 2));
+                  const ty = Math.max(PT + 12, y - 10);
+                  return { x, y, label, tw, tx, ty };
+              })()
+            : null;
 
     return (
         <svg viewBox={`0 0 ${CW} ${CH}`} width="100%" class="stats-chart" aria-hidden="true">
@@ -134,20 +229,25 @@ function MonthlyChart({ data }: { data: number[] }) {
             </defs>
 
             {/* Gridlines */}
-            <line x1={PL} y1={toY(maxArea * 0.5)} x2={CW - PR} y2={toY(maxArea * 0.5)} class="stats-chart-grid" />
+            <line x1={PL} y1={toY(maxVal * 0.5)} x2={CW - PR} y2={toY(maxVal * 0.5)} class="stats-chart-grid" />
             <line x1={PL} y1={PT} x2={CW - PR} y2={PT} class="stats-chart-grid" />
 
             {/* Y-axis labels */}
             <text x={PL - 4} y={PT + 4} textAnchor="end" class="stats-chart-label">
-                {maxArea.toFixed(1)}
+                {metricAxisLabel(maxVal, metric)}
             </text>
-            <text x={PL - 4} y={toY(maxArea * 0.5) + 4} textAnchor="end" class="stats-chart-label">
-                {(maxArea * 0.5).toFixed(1)}
+            <text x={PL - 4} y={toY(maxVal * 0.5) + 4} textAnchor="end" class="stats-chart-label">
+                {metricAxisLabel(maxVal * 0.5, metric)}
             </text>
 
             {/* Area fill + line */}
             {area && <path d={area} class="stats-chart-area" />}
             {line && <path d={line} class="stats-chart-line" />}
+
+            {/* Selected month vertical line */}
+            {tooltip && (
+                <line x1={tooltip.x} y1={PT} x2={tooltip.x} y2={baseline} class="stats-chart-selector" />
+            )}
 
             {/* X-axis month labels */}
             {MONTH_LABELS.map((label, i) => (
@@ -156,7 +256,7 @@ function MonthlyChart({ data }: { data: number[] }) {
                     x={PL + i * slotW + slotW / 2}
                     y={CH - 4}
                     textAnchor="middle"
-                    class="stats-chart-label"
+                    class={`stats-chart-label${i === selectedMonth ? " stats-chart-label-sel" : ""}`}
                 >
                     {label}
                 </text>
@@ -164,6 +264,43 @@ function MonthlyChart({ data }: { data: number[] }) {
 
             {/* Baseline */}
             <line x1={PL} y1={baseline} x2={CW - PR} y2={baseline} class="stats-chart-baseline" />
+
+            {/* Click zones */}
+            {MONTH_LABELS.map((_, i) => (
+                <rect
+                    key={i}
+                    x={PL + i * slotW}
+                    y={PT}
+                    width={slotW}
+                    height={CHART_H + PB}
+                    fill="transparent"
+                    style="cursor:pointer"
+                    onClick={() => onSelectMonth(i === selectedMonth ? null : i)}
+                />
+            ))}
+
+            {/* Tooltip (rendered last so it sits on top) */}
+            {tooltip && (
+                <g style="pointer-events:none">
+                    <circle cx={tooltip.x} cy={tooltip.y} r={3} class="stats-chart-dot" />
+                    <rect
+                        x={tooltip.tx - 2}
+                        y={tooltip.ty - 10}
+                        width={tooltip.tw}
+                        height={14}
+                        rx={3}
+                        class="stats-chart-tooltip-bg"
+                    />
+                    <text
+                        x={tooltip.tx + tooltip.tw / 2}
+                        y={tooltip.ty}
+                        textAnchor="middle"
+                        class="stats-chart-tooltip-text"
+                    >
+                        {tooltip.label}
+                    </text>
+                </g>
+            )}
         </svg>
     );
 }
@@ -190,6 +327,8 @@ export function StatsView() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+    const [selectedMetric, setSelectedMetric] = useState<ChartMetric>("area");
+    const [selectedMonth, setSelectedMonth] = useState<number | null>(null);
 
     useEffect(() => {
         api.getHistoryList()
@@ -209,7 +348,8 @@ export function StatsView() {
     }, []);
 
     const dist = stats ? formatDistance(stats.totalDistance) : { value: "0", unit: "m" };
-    const monthlyData = stats?.monthlyByYear[selectedYear] ?? Array(12).fill(0);
+    const monthlyData = stats?.monthlyByYear[selectedYear] ?? EMPTY_MONTHLY;
+    const unit = METRIC_UNITS[selectedMetric];
 
     return (
         <>
@@ -238,24 +378,54 @@ export function StatsView() {
 
                         <div class="stats-section">
                             <div class="stats-section-header">
-                                <div class="stats-section-title">Area covered · {selectedYear}</div>
-                                {stats.availableYears.length > 1 && (
-                                    <div class="stats-year-picker">
-                                        {stats.availableYears.map((y) => (
+                                <div class="stats-section-title">
+                                    {METRIC_TITLES[selectedMetric]} · {selectedYear}
+                                </div>
+                                {stats.availableYears.length > 1 && (() => {
+                                    const idx = stats.availableYears.indexOf(selectedYear);
+                                    return (
+                                        <div class="stats-year-nav">
                                             <button
-                                                key={y}
                                                 type="button"
-                                                class={`stats-year-btn${y === selectedYear ? " active" : ""}`}
-                                                onClick={() => setSelectedYear(y)}
+                                                class="stats-year-nav-btn"
+                                                disabled={idx >= stats.availableYears.length - 1}
+                                                onClick={() => setSelectedYear(stats.availableYears[idx + 1])}
+                                                aria-label="Previous year"
                                             >
-                                                {y}
+                                                ‹
                                             </button>
-                                        ))}
-                                    </div>
-                                )}
+                                            <button
+                                                type="button"
+                                                class="stats-year-nav-btn"
+                                                disabled={idx <= 0}
+                                                onClick={() => setSelectedYear(stats.availableYears[idx - 1])}
+                                                aria-label="Next year"
+                                            >
+                                                ›
+                                            </button>
+                                        </div>
+                                    );
+                                })()}
                             </div>
-                            <MonthlyChart data={monthlyData} />
-                            <div class="stats-chart-unit">m²</div>
+                            <div class="stats-metric-picker">
+                                {METRICS.map(({ key, label }) => (
+                                    <button
+                                        key={key}
+                                        type="button"
+                                        class={`stats-metric-btn${key === selectedMetric ? " active" : ""}`}
+                                        onClick={() => setSelectedMetric(key)}
+                                    >
+                                        {label}
+                                    </button>
+                                ))}
+                            </div>
+                            <MonthlyChart
+                                data={monthlyData[selectedMetric]}
+                                metric={selectedMetric}
+                                selectedMonth={selectedMonth}
+                                onSelectMonth={setSelectedMonth}
+                            />
+                            {unit && <div class="stats-chart-unit">{unit}</div>}
                         </div>
 
                         <div class="stats-section">

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -7,7 +7,6 @@ import type { HistoryFileInfo } from "../types";
 import { normalizeError } from "../utils";
 import { formatDuration } from "./history/helpers";
 
-const NUM_WEEKS = 10;
 const MS_WEEK = 7 * 86400 * 1000;
 
 function weekStartMs(epochMs: number): number {
@@ -65,8 +64,14 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
     }
 
     const thisWeek = weekStartMs(Date.now());
-    const weekly: WeekBucket[] = Array.from({ length: NUM_WEEKS }, (_, i) => {
-        const startMs = thisWeek - (NUM_WEEKS - 1 - i) * MS_WEEK;
+    const sessionsWithTime = finished.filter((f) => f.session);
+    const oldestWeek =
+        sessionsWithTime.length > 0
+            ? weekStartMs(Math.min(...sessionsWithTime.map((f) => f.session!.time * 1000)))
+            : thisWeek;
+    const numWeeks = Math.max(1, Math.round((thisWeek - oldestWeek) / MS_WEEK) + 1);
+    const weekly: WeekBucket[] = Array.from({ length: numWeeks }, (_, i) => {
+        const startMs = thisWeek - (numWeeks - 1 - i) * MS_WEEK;
         const d = new Date(startMs);
         return { startMs, label: `${d.getUTCMonth() + 1}/${d.getUTCDate()}`, area: 0 };
     });
@@ -108,7 +113,8 @@ const CHART_H = CH - PT - PB;
 function WeeklyChart({ data }: { data: WeekBucket[] }) {
     const maxArea = Math.max(...data.map((d) => d.area), 0.01);
     const slotW = CHART_W / data.length;
-    const barW = Math.max(slotW * 0.62, 4);
+    const barW = Math.max(slotW * 0.62, 2);
+    const labelEvery = data.length <= 12 ? 1 : data.length <= 26 ? 2 : data.length <= 52 ? 4 : 8;
 
     const toY = (area: number) => PT + CHART_H * (1 - area / maxArea);
 
@@ -136,7 +142,7 @@ function WeeklyChart({ data }: { data: WeekBucket[] }) {
                 return (
                     <g key={d.startMs}>
                         {bh > 0 && <rect x={bx} y={by} width={barW} height={bh} class="stats-chart-bar" rx="2" />}
-                        {i % 2 === 0 && (
+                        {i % labelEvery === 0 && (
                             <text x={lx} y={CH - 4} textAnchor="middle" class="stats-chart-label">
                                 {d.label}
                             </text>
@@ -214,7 +220,7 @@ export function StatsView() {
                         </div>
 
                         <div class="stats-section">
-                            <div class="stats-section-title">Area covered · last 10 weeks</div>
+                            <div class="stats-section-title">Area covered · by week</div>
                             <WeeklyChart data={stats.weekly} />
                             <div class="stats-chart-unit">m²</div>
                         </div>

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useState } from "preact/hooks";
+import { api, ResponseParseError } from "../api";
+import backSvg from "../assets/icons/back.svg?raw";
+import { Icon } from "../components/icon";
+import { useNavigate } from "../components/router";
+import type { HistoryFileInfo } from "../types";
+import { normalizeError } from "../utils";
+import { formatDuration } from "./history/helpers";
+
+const NUM_WEEKS = 10;
+const MS_WEEK = 7 * 86400 * 1000;
+
+function weekStartMs(epochMs: number): number {
+    const d = new Date(epochMs);
+    const dow = (d.getUTCDay() + 6) % 7; // Mon=0 … Sun=6
+    return (
+        epochMs -
+        dow * 86400000 -
+        (d.getUTCHours() * 3600 + d.getUTCMinutes() * 60 + d.getUTCSeconds()) * 1000 -
+        d.getUTCMilliseconds()
+    );
+}
+
+interface WeekBucket {
+    startMs: number;
+    label: string;
+    area: number;
+}
+
+interface StatsData {
+    totalCleans: number;
+    totalArea: number;
+    totalDistance: number;
+    totalDuration: number;
+    avgBatteryUsed: number | null;
+    weekly: WeekBucket[];
+    modeCounts: { house: number; spot: number; manual: number };
+}
+
+function computeStats(files: HistoryFileInfo[]): StatsData {
+    const finished = files.filter((f) => f.summary && !f.recording);
+
+    let totalArea = 0;
+    let totalDistance = 0;
+    let totalDuration = 0;
+    let batterySum = 0;
+    let batteryCount = 0;
+    const modeCounts = { house: 0, spot: 0, manual: 0 };
+
+    for (const f of finished) {
+        if (!f.summary) continue;
+        const s = f.summary;
+        totalArea += s.areaCovered;
+        totalDistance += s.distanceTraveled;
+        totalDuration += s.duration;
+        const battStart = s.batteryStart ?? f.session?.battery;
+        if (battStart != null && s.batteryEnd != null) {
+            batterySum += battStart - s.batteryEnd;
+            batteryCount++;
+        }
+        const mode = (f.session?.mode ?? s.mode).toLowerCase();
+        if (mode === "house") modeCounts.house++;
+        else if (mode === "spot") modeCounts.spot++;
+        else modeCounts.manual++;
+    }
+
+    const thisWeek = weekStartMs(Date.now());
+    const weekly: WeekBucket[] = Array.from({ length: NUM_WEEKS }, (_, i) => {
+        const startMs = thisWeek - (NUM_WEEKS - 1 - i) * MS_WEEK;
+        const d = new Date(startMs);
+        return { startMs, label: `${d.getUTCMonth() + 1}/${d.getUTCDate()}`, area: 0 };
+    });
+
+    for (const f of finished) {
+        if (!f.session || !f.summary) continue;
+        const ws = weekStartMs(f.session.time * 1000);
+        const b = weekly.find((w) => w.startMs === ws);
+        if (b) b.area += f.summary.areaCovered;
+    }
+
+    return {
+        totalCleans: finished.length,
+        totalArea,
+        totalDistance,
+        totalDuration,
+        avgBatteryUsed: batteryCount > 0 ? batterySum / batteryCount : null,
+        weekly,
+        modeCounts,
+    };
+}
+
+function formatDistance(m: number): { value: string; unit: string } {
+    if (m >= 1000) return { value: (m / 1000).toFixed(1), unit: "km" };
+    return { value: m.toFixed(0), unit: "m" };
+}
+
+// -- Chart ---------------------------------------------------------------
+
+const CW = 360;
+const CH = 150;
+const PL = 32; // left (y-axis labels)
+const PR = 6;
+const PT = 8;
+const PB = 26; // bottom (x-axis labels)
+const CHART_W = CW - PL - PR;
+const CHART_H = CH - PT - PB;
+
+function WeeklyChart({ data }: { data: WeekBucket[] }) {
+    const maxArea = Math.max(...data.map((d) => d.area), 0.01);
+    const slotW = CHART_W / data.length;
+    const barW = Math.max(slotW * 0.62, 4);
+
+    const toY = (area: number) => PT + CHART_H * (1 - area / maxArea);
+
+    return (
+        <svg viewBox={`0 0 ${CW} ${CH}`} width="100%" class="stats-chart" aria-hidden="true">
+            {/* 50% gridline */}
+            <line x1={PL} y1={toY(maxArea * 0.5)} x2={CW - PR} y2={toY(maxArea * 0.5)} class="stats-chart-grid" />
+            {/* 100% gridline */}
+            <line x1={PL} y1={PT} x2={CW - PR} y2={PT} class="stats-chart-grid" />
+
+            {/* Y-axis labels */}
+            <text x={PL - 4} y={PT + 4} textAnchor="end" class="stats-chart-label">
+                {maxArea.toFixed(1)}
+            </text>
+            <text x={PL - 4} y={toY(maxArea * 0.5) + 4} textAnchor="end" class="stats-chart-label">
+                {(maxArea * 0.5).toFixed(1)}
+            </text>
+
+            {/* Bars + x labels */}
+            {data.map((d, i) => {
+                const bh = (d.area / maxArea) * CHART_H;
+                const bx = PL + i * slotW + (slotW - barW) / 2;
+                const by = PT + CHART_H - bh;
+                const lx = PL + i * slotW + slotW / 2;
+                return (
+                    <g key={d.startMs}>
+                        {bh > 0 && <rect x={bx} y={by} width={barW} height={bh} class="stats-chart-bar" rx="2" />}
+                        {i % 2 === 0 && (
+                            <text x={lx} y={CH - 4} textAnchor="middle" class="stats-chart-label">
+                                {d.label}
+                            </text>
+                        )}
+                    </g>
+                );
+            })}
+
+            {/* Baseline */}
+            <line x1={PL} y1={PT + CHART_H} x2={CW - PR} y2={PT + CHART_H} class="stats-chart-baseline" />
+        </svg>
+    );
+}
+
+// -- Stat card -----------------------------------------------------------
+
+function StatCard({ label, value, unit }: { label: string; value: string; unit?: string }) {
+    return (
+        <div class="stats-card">
+            <div class="stats-card-label">{label}</div>
+            <div class="stats-card-value">
+                {value}
+                {unit && <span class="stats-card-unit"> {unit}</span>}
+            </div>
+        </div>
+    );
+}
+
+// -- View ----------------------------------------------------------------
+
+export function StatsView() {
+    const navigate = useNavigate();
+    const [stats, setStats] = useState<StatsData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        api.getHistoryList()
+            .then((files) => setStats(computeStats(files)))
+            .catch((e: unknown) => {
+                const msg =
+                    e instanceof ResponseParseError
+                        ? "History data is corrupted — use the Cleaning History page to recover."
+                        : normalizeError(e, "Failed to load history");
+                setError(msg);
+            })
+            .finally(() => setLoading(false));
+    }, []);
+
+    const dist = stats ? formatDistance(stats.totalDistance) : { value: "0", unit: "m" };
+
+    return (
+        <>
+            <div class="header">
+                <button type="button" class="header-back-btn" onClick={() => navigate("/")} aria-label="Back">
+                    <Icon svg={backSvg} />
+                </button>
+                <h1>Statistics</h1>
+                <div class="header-right-spacer" />
+            </div>
+
+            <div class="stats-page">
+                {loading && <div class="stats-empty">Loading...</div>}
+                {error && <div class="stats-empty">{error}</div>}
+
+                {stats && stats.totalCleans === 0 && <div class="stats-empty">No completed cleans yet</div>}
+
+                {stats && stats.totalCleans > 0 && (
+                    <>
+                        <div class="stats-totals">
+                            <StatCard label="Total cleans" value={String(stats.totalCleans)} />
+                            <StatCard label="Area covered" value={stats.totalArea.toFixed(1)} unit="m²" />
+                            <StatCard label="Distance" value={dist.value} unit={dist.unit} />
+                            <StatCard label="Runtime" value={formatDuration(stats.totalDuration)} />
+                        </div>
+
+                        <div class="stats-section">
+                            <div class="stats-section-title">Area covered · last 10 weeks</div>
+                            <WeeklyChart data={stats.weekly} />
+                            <div class="stats-chart-unit">m²</div>
+                        </div>
+
+                        <div class="stats-section">
+                            <div class="stats-section-title">Cleaning mode</div>
+                            <div class="stats-modes">
+                                <div class="stats-mode-pill">
+                                    <div class="stats-mode-count">{stats.modeCounts.house}</div>
+                                    <div class="stats-mode-label">House</div>
+                                </div>
+                                <div class="stats-mode-pill">
+                                    <div class="stats-mode-count">{stats.modeCounts.spot}</div>
+                                    <div class="stats-mode-label">Spot</div>
+                                </div>
+                                {stats.modeCounts.manual > 0 && (
+                                    <div class="stats-mode-pill">
+                                        <div class="stats-mode-count">{stats.modeCounts.manual}</div>
+                                        <div class="stats-mode-label">Manual</div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        {stats.avgBatteryUsed !== null && (
+                            <div class="stats-section stats-battery-row">
+                                <span class="stats-section-title">Avg battery per clean</span>
+                                <span class="stats-battery-value">{Math.round(stats.avgBatteryUsed)}%</span>
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </>
+    );
+}

--- a/frontend/src/views/stats.tsx
+++ b/frontend/src/views/stats.tsx
@@ -7,24 +7,7 @@ import type { HistoryFileInfo } from "../types";
 import { normalizeError } from "../utils";
 import { formatDuration } from "./history/helpers";
 
-const MS_WEEK = 7 * 86400 * 1000;
-
-function weekStartMs(epochMs: number): number {
-    const d = new Date(epochMs);
-    const dow = (d.getUTCDay() + 6) % 7; // Mon=0 … Sun=6
-    return (
-        epochMs -
-        dow * 86400000 -
-        (d.getUTCHours() * 3600 + d.getUTCMinutes() * 60 + d.getUTCSeconds()) * 1000 -
-        d.getUTCMilliseconds()
-    );
-}
-
-interface WeekBucket {
-    startMs: number;
-    label: string;
-    area: number;
-}
+const MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 interface StatsData {
     totalCleans: number;
@@ -32,7 +15,8 @@ interface StatsData {
     totalDistance: number;
     totalDuration: number;
     avgBatteryUsed: number | null;
-    weekly: WeekBucket[];
+    availableYears: number[];
+    monthlyByYear: Record<number, number[]>;
     modeCounts: { house: number; spot: number; manual: number };
 }
 
@@ -45,6 +29,7 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
     let batterySum = 0;
     let batteryCount = 0;
     const modeCounts = { house: 0, spot: 0, manual: 0 };
+    const monthlyByYear: Record<number, number[]> = {};
 
     for (const f of finished) {
         if (!f.summary) continue;
@@ -61,27 +46,19 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
         if (mode === "house") modeCounts.house++;
         else if (mode === "spot") modeCounts.spot++;
         else modeCounts.manual++;
+
+        if (f.session) {
+            const d = new Date(f.session.time * 1000);
+            const year = d.getUTCFullYear();
+            const month = d.getUTCMonth();
+            if (!monthlyByYear[year]) monthlyByYear[year] = Array(12).fill(0);
+            monthlyByYear[year][month] += s.areaCovered;
+        }
     }
 
-    const thisWeek = weekStartMs(Date.now());
-    const sessionsWithTime = finished.filter((f) => f.session);
-    const oldestWeek =
-        sessionsWithTime.length > 0
-            ? weekStartMs(Math.min(...sessionsWithTime.map((f) => f.session!.time * 1000)))
-            : thisWeek;
-    const numWeeks = Math.max(1, Math.round((thisWeek - oldestWeek) / MS_WEEK) + 1);
-    const weekly: WeekBucket[] = Array.from({ length: numWeeks }, (_, i) => {
-        const startMs = thisWeek - (numWeeks - 1 - i) * MS_WEEK;
-        const d = new Date(startMs);
-        return { startMs, label: `${d.getUTCMonth() + 1}/${d.getUTCDate()}`, area: 0 };
-    });
-
-    for (const f of finished) {
-        if (!f.session || !f.summary) continue;
-        const ws = weekStartMs(f.session.time * 1000);
-        const b = weekly.find((w) => w.startMs === ws);
-        if (b) b.area += f.summary.areaCovered;
-    }
+    const availableYears = Object.keys(monthlyByYear)
+        .map(Number)
+        .sort((a, b) => b - a);
 
     return {
         totalCleans: finished.length,
@@ -89,7 +66,8 @@ function computeStats(files: HistoryFileInfo[]): StatsData {
         totalDistance,
         totalDuration,
         avgBatteryUsed: batteryCount > 0 ? batterySum / batteryCount : null,
-        weekly,
+        availableYears,
+        monthlyByYear,
         modeCounts,
     };
 }
@@ -103,26 +81,60 @@ function formatDistance(m: number): { value: string; unit: string } {
 
 const CW = 360;
 const CH = 150;
-const PL = 32; // left (y-axis labels)
+const PL = 32;
 const PR = 6;
 const PT = 8;
-const PB = 26; // bottom (x-axis labels)
+const PB = 26;
 const CHART_W = CW - PL - PR;
 const CHART_H = CH - PT - PB;
 
-function WeeklyChart({ data }: { data: WeekBucket[] }) {
-    const maxArea = Math.max(...data.map((d) => d.area), 0.01);
-    const slotW = CHART_W / data.length;
-    const barW = Math.max(slotW * 0.62, 2);
-    const labelEvery = data.length <= 12 ? 1 : data.length <= 26 ? 2 : data.length <= 52 ? 4 : 8;
+function smoothPaths(points: [number, number][], baseline: number): { area: string; line: string } {
+    if (points.length === 0) return { area: "", line: "" };
+
+    let line = `M ${points[0][0].toFixed(2)} ${points[0][1].toFixed(2)}`;
+
+    for (let i = 0; i < points.length - 1; i++) {
+        const p0 = points[Math.max(0, i - 1)];
+        const p1 = points[i];
+        const p2 = points[i + 1];
+        const p3 = points[Math.min(points.length - 1, i + 2)];
+
+        const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
+        const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
+        const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
+        const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
+
+        line += ` C ${cp1x.toFixed(2)} ${cp1y.toFixed(2)},${cp2x.toFixed(2)} ${cp2y.toFixed(2)},${p2[0].toFixed(2)} ${p2[1].toFixed(2)}`;
+    }
+
+    const first = points[0];
+    const last = points[points.length - 1];
+    const area = `${line} L ${last[0].toFixed(2)} ${baseline} L ${first[0].toFixed(2)} ${baseline} Z`;
+
+    return { area, line };
+}
+
+function MonthlyChart({ data }: { data: number[] }) {
+    const maxArea = Math.max(...data, 0.01);
+    const slotW = CHART_W / 12;
+    const baseline = PT + CHART_H;
 
     const toY = (area: number) => PT + CHART_H * (1 - area / maxArea);
 
+    const points: [number, number][] = data.map((area, i) => [PL + i * slotW + slotW / 2, toY(area)]);
+    const { area, line } = smoothPaths(points, baseline);
+
     return (
         <svg viewBox={`0 0 ${CW} ${CH}`} width="100%" class="stats-chart" aria-hidden="true">
-            {/* 50% gridline */}
+            <defs>
+                <linearGradient id="stats-area-grad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" class="stats-area-grad-top" />
+                    <stop offset="100%" class="stats-area-grad-bottom" />
+                </linearGradient>
+            </defs>
+
+            {/* Gridlines */}
             <line x1={PL} y1={toY(maxArea * 0.5)} x2={CW - PR} y2={toY(maxArea * 0.5)} class="stats-chart-grid" />
-            {/* 100% gridline */}
             <line x1={PL} y1={PT} x2={CW - PR} y2={PT} class="stats-chart-grid" />
 
             {/* Y-axis labels */}
@@ -133,26 +145,25 @@ function WeeklyChart({ data }: { data: WeekBucket[] }) {
                 {(maxArea * 0.5).toFixed(1)}
             </text>
 
-            {/* Bars + x labels */}
-            {data.map((d, i) => {
-                const bh = (d.area / maxArea) * CHART_H;
-                const bx = PL + i * slotW + (slotW - barW) / 2;
-                const by = PT + CHART_H - bh;
-                const lx = PL + i * slotW + slotW / 2;
-                return (
-                    <g key={d.startMs}>
-                        {bh > 0 && <rect x={bx} y={by} width={barW} height={bh} class="stats-chart-bar" rx="2" />}
-                        {i % labelEvery === 0 && (
-                            <text x={lx} y={CH - 4} textAnchor="middle" class="stats-chart-label">
-                                {d.label}
-                            </text>
-                        )}
-                    </g>
-                );
-            })}
+            {/* Area fill + line */}
+            {area && <path d={area} class="stats-chart-area" />}
+            {line && <path d={line} class="stats-chart-line" />}
+
+            {/* X-axis month labels */}
+            {MONTH_LABELS.map((label, i) => (
+                <text
+                    key={label}
+                    x={PL + i * slotW + slotW / 2}
+                    y={CH - 4}
+                    textAnchor="middle"
+                    class="stats-chart-label"
+                >
+                    {label}
+                </text>
+            ))}
 
             {/* Baseline */}
-            <line x1={PL} y1={PT + CHART_H} x2={CW - PR} y2={PT + CHART_H} class="stats-chart-baseline" />
+            <line x1={PL} y1={baseline} x2={CW - PR} y2={baseline} class="stats-chart-baseline" />
         </svg>
     );
 }
@@ -178,10 +189,15 @@ export function StatsView() {
     const [stats, setStats] = useState<StatsData | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
 
     useEffect(() => {
         api.getHistoryList()
-            .then((files) => setStats(computeStats(files)))
+            .then((files) => {
+                const s = computeStats(files);
+                setStats(s);
+                if (s.availableYears.length > 0) setSelectedYear(s.availableYears[0]);
+            })
             .catch((e: unknown) => {
                 const msg =
                     e instanceof ResponseParseError
@@ -193,6 +209,7 @@ export function StatsView() {
     }, []);
 
     const dist = stats ? formatDistance(stats.totalDistance) : { value: "0", unit: "m" };
+    const monthlyData = stats?.monthlyByYear[selectedYear] ?? Array(12).fill(0);
 
     return (
         <>
@@ -220,8 +237,24 @@ export function StatsView() {
                         </div>
 
                         <div class="stats-section">
-                            <div class="stats-section-title">Area covered · by week</div>
-                            <WeeklyChart data={stats.weekly} />
+                            <div class="stats-section-header">
+                                <div class="stats-section-title">Area covered · {selectedYear}</div>
+                                {stats.availableYears.length > 1 && (
+                                    <div class="stats-year-picker">
+                                        {stats.availableYears.map((y) => (
+                                            <button
+                                                key={y}
+                                                type="button"
+                                                class={`stats-year-btn${y === selectedYear ? " active" : ""}`}
+                                                onClick={() => setSelectedYear(y)}
+                                            >
+                                                {y}
+                                            </button>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                            <MonthlyChart data={monthlyData} />
                             <div class="stats-chart-unit">m²</div>
                         </div>
 


### PR DESCRIPTION
Adds a Statistics page accessible from the Cleaning History header (chart icon).

- 4 total cards: cleans, area covered, distance (auto-scales to km), runtime
- SVG bar chart of area covered per week over the last 10 weeks (no dependencies)
- Mode breakdown (House / Spot / Manual)
- Average battery used per clean
- Stats button hidden when history is corrupted (recovery flow unaffected)

Pure frontend — no firmware changes.