### PR TITLE
ci: make PlatformIO env discovery reusable

### DIFF
--- a/.github/actions/list-pio-envs/action.yml
+++ b/.github/actions/list-pio-envs/action.yml
@@ -1,0 +1,42 @@
+name: List PlatformIO environments
+description: Set up PlatformIO and list project environments for a given mode
+
+inputs:
+  mode:
+    description: Environment mode suffix to list
+    required: true
+
+outputs:
+  envs-json:
+    description: Matching environments as a JSON array
+    value: ${{ steps.list.outputs.envs_json }}
+  envs-lines:
+    description: Matching environments as newline-delimited text
+    value: ${{ steps.list.outputs.envs_lines }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: .github/platformio-requirements.txt
+
+    - name: Install PlatformIO
+      shell: bash
+      run: pip install -r .github/platformio-requirements.txt
+
+    - name: List environments
+      id: list
+      shell: bash
+      run: |
+        ENVS_JSON=$(pio project config --json-output | jq -c --arg suffix "-${{ inputs.mode }}" '[.[] | .[0] | select(startswith("env:") and endswith($suffix)) | sub("^env:"; "")]')
+        ENVS_LINES=$(printf '%s\n' "$ENVS_JSON" | jq -r '.[]')
+        {
+          echo "envs_json=$ENVS_JSON"
+          echo "envs_lines<<EOF"
+          printf '%s\n' "$ENVS_LINES"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/platformio-requirements.txt
+++ b/.github/platformio-requirements.txt
@@ -1,0 +1,1 @@
+platformio==6.1.19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,28 @@ permissions:
   contents: read
 
 jobs:
+  firmware-matrix:
+    name: Resolve firmware matrix
+    runs-on: ubuntu-latest
+    outputs:
+      envs: ${{ steps.envs.outputs.envs-json }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: List debug environments
+        id: envs
+        uses: ./.github/actions/list-pio-envs
+        with:
+          mode: debug
+
   firmware:
     name: Firmware (${{ matrix.env }})
     runs-on: ubuntu-latest
+    needs: firmware-matrix
     strategy:
       fail-fast: false
       matrix:
-        env: [c3-debug, s3-debug, esp32-debug]
+        env: ${{ fromJson(needs.firmware-matrix.outputs.envs) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,17 +47,21 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: .github/platformio-requirements.txt
 
       - name: Cache PlatformIO
         uses: actions/cache@v4
         with:
           path: |
+            ~/.platformio/.cache
             ~/.platformio/platforms
             ~/.platformio/packages
+            .pio/libdeps
           key: platformio-${{ matrix.env }}-${{ hashFiles('platformio.ini') }}
 
       - name: Install PlatformIO
-        run: pip install platformio
+        run: pip install -r .github/platformio-requirements.txt
 
       - name: Build firmware
         run: pio run -e ${{ matrix.env }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -68,10 +68,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Release: $TAG ($HEAD_REF @ $SHORT_SHA)"
 
-  prerelease:
-    name: Build and Prerelease
-    runs-on: macos-latest
+  create-tag:
+    name: Create release tag
     needs: resolve
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -87,7 +87,36 @@ jobs:
           git tag -a "${{ needs.resolve.outputs.release_tag }}" -m "Prerelease ${{ needs.resolve.outputs.release_tag }}"
           git push origin "${{ needs.resolve.outputs.release_tag }}"
 
-      # --- Frontend ---
+  resolve-firmware-envs:
+    name: Resolve firmware environments
+    needs: [resolve, create-tag]
+    runs-on: ubuntu-latest
+    outputs:
+      envs: ${{ steps.envs.outputs.envs-json }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.release_tag }}
+
+      - name: List release environments
+        id: envs
+        uses: ./.github/actions/list-pio-envs
+        with:
+          mode: release
+
+  frontend-assets:
+    name: Build frontend assets
+    needs: [resolve, create-tag]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.release_tag }}
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -104,32 +133,86 @@ jobs:
         run: npm run build
         working-directory: frontend
 
-      # --- Firmware ---
+      - name: Upload embedded frontend header
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-assets
+          path: firmware/src/web_assets.h
+
+  firmware:
+    name: Firmware (${{ matrix.env }})
+    needs: [resolve, create-tag, resolve-firmware-envs, frontend-assets]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJson(needs.resolve-firmware-envs.outputs.envs) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Download embedded frontend header
+        uses: actions/download-artifact@v4
+        with:
+          name: web-assets
+          path: firmware/src
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: .github/platformio-requirements.txt
 
       - name: Cache PlatformIO
         uses: actions/cache@v4
         with:
           path: |
+            ~/.platformio/.cache
             ~/.platformio/platforms
             ~/.platformio/packages
-          key: platformio-${{ hashFiles('platformio.ini') }}
+            .pio/libdeps
+          key: platformio-${{ matrix.env }}-${{ hashFiles('platformio.ini') }}
 
       - name: Install PlatformIO
-        run: pip install platformio
+        run: pip install -r .github/platformio-requirements.txt
 
       - name: Build firmware
         env:
           FIRMWARE_VERSION: ${{ needs.resolve.outputs.version }}
         run: |
-          while IFS= read -r env; do
-            echo "Building $env..."
-            pio run -e "$env"
-          done < <(grep -oE '^\[env:([a-zA-Z0-9_-]+-release)\]' platformio.ini | sed 's/\[env:\(.*\)\]/\1/')
+          echo "Building ${{ matrix.env }}..."
+          pio run -e "${{ matrix.env }}"
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.env }}
+          path: |
+            .pio/build/${{ matrix.env }}/*-firmware.bin
+            .pio/build/${{ matrix.env }}/*-full.tar.gz
+
+  prerelease:
+    name: Build and Prerelease
+    runs-on: macos-latest
+    needs: [resolve, create-tag, firmware]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '*-release'
+          path: .pio/build
 
       # --- Flash tool + GitHub Release ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,29 @@ jobs:
           name: release-notes
           path: release_notes.md
 
-  release:
-    name: Build and Release
-    runs-on: macos-latest
+  resolve-firmware-envs:
+    name: Resolve firmware environments
     needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      envs: ${{ steps.envs.outputs.envs-json }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.release_tag }}
+
+      - name: List release environments
+        id: envs
+        uses: ./.github/actions/list-pio-envs
+        with:
+          mode: release
+
+  frontend-assets:
+    name: Build frontend assets
+    needs: prepare
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -84,8 +103,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.release_tag }}
-
-      # --- Frontend ---
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -102,34 +119,86 @@ jobs:
         run: npm run build
         working-directory: frontend
 
-      # --- Firmware ---
+      - name: Upload embedded frontend header
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-assets
+          path: firmware/src/web_assets.h
+
+  firmware:
+    name: Firmware (${{ matrix.env }})
+    needs: [prepare, resolve-firmware-envs, frontend-assets]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJson(needs.resolve-firmware-envs.outputs.envs) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.release_tag }}
+
+      - name: Download embedded frontend header
+        uses: actions/download-artifact@v4
+        with:
+          name: web-assets
+          path: firmware/src
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: .github/platformio-requirements.txt
 
       - name: Cache PlatformIO
         uses: actions/cache@v4
         with:
           path: |
+            ~/.platformio/.cache
             ~/.platformio/platforms
             ~/.platformio/packages
-          key: platformio-${{ hashFiles('platformio.ini') }}
+            .pio/libdeps
+          key: platformio-${{ matrix.env }}-${{ hashFiles('platformio.ini') }}
 
       - name: Install PlatformIO
-        run: pip install platformio
+        run: pip install -r .github/platformio-requirements.txt
 
       - name: Build firmware and package release artifacts
         env:
           FIRMWARE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          # Build all *-release environments; post-build hook packages
-          # firmware artifacts into each env's build dir for GoReleaser
-          while IFS= read -r env; do
-            echo "Building $env..."
-            pio run -e "$env"
-          done < <(grep -oE '^\[env:([a-zA-Z0-9_-]+-release)\]' platformio.ini | sed 's/\[env:\(.*\)\]/\1/')
+          echo "Building ${{ matrix.env }}..."
+          pio run -e "${{ matrix.env }}"
+
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.env }}
+          path: |
+            .pio/build/${{ matrix.env }}/*-firmware.bin
+            .pio/build/${{ matrix.env }}/*-full.tar.gz
+
+  release:
+    name: Build and Release
+    runs-on: macos-latest
+    needs: [prepare, firmware]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.release_tag }}
+
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '*-release'
+          path: .pio/build
 
       # --- Flash tool + GitHub Release ---
 


### PR DESCRIPTION
Refactors CI, release, and prerelease workflows to discover PlatformIO environments from a shared local action.

Changes:
- Add a local action to list PlatformIO environments by mode
- Build the CI firmware matrix from discovered debug environments
- Run release and prerelease firmware builds in parallel per target
