### PR TITLE
Use robot state for scheduler idle check

### DIFF
--- a/docs/neato-serial-protocol.md
+++ b/docs/neato-serial-protocol.md
@@ -588,6 +588,12 @@ Complete list from firmware 3.2.0 (unchanged in 4.5.3):
 - `UIMGR_STATE_OTA_LOGUPLOAD`
 - `UIMGR_STATE_INVALID`
 
+Note: the UI state is not a reliable idle indicator. A D6 Connected on 4.5.3 has
+been observed stuck in `UIMGR_STATE_STARTHOUSECLEANING` while docked and idle
+(`ST_C_Standby`) after a clean that raised `UI_ALERT_PM_LOAD_FAIL`. Prefer the
+robot state (below) for idle detection whenever it is present
+(`RobotState::isIdle()`).
+
 ## Robot States (ST_*)
 
 Reported in `GetState` second line (`Current Robot State is:`). Available in

--- a/firmware/src/neato_commands.cpp
+++ b/firmware/src/neato_commands.cpp
@@ -558,6 +558,13 @@ bool parseMotorData(const String& raw, MotorData& out) {
     return found;
 }
 
+bool RobotState::isIdle() const {
+    if (robotState.length() > 0) {
+        return robotState == "ST_C_Standby" || robotState == "ST_C_Idle" || robotState == "ST_M2_Charging_StdBy";
+    }
+    return uiState == "UIMGR_STATE_IDLE" || uiState == "UIMGR_STATE_STANDBY";
+}
+
 bool parseRobotState(const String& raw, RobotState& out) {
     // Format: "Current UI State is: UIMGR_STATE_STANDBY\r\n"
     //         "Current Robot State is: ST_C_Standby\r\n"

--- a/firmware/src/neato_commands.h
+++ b/firmware/src/neato_commands.h
@@ -171,6 +171,11 @@ struct RobotState : public JsonSerializable {
     String uiState; // e.g. "UIMGR_STATE_STANDBY"
     String robotState; // e.g. "ST_C_Standby"
 
+    // Prefers robotState (4.5.3+): uiState can stay at UIMGR_STATE_STARTHOUSECLEANING
+    // after a clean while the robot is back in standby. Falls back to uiState on
+    // older firmware that reports no robot state.
+    bool isIdle() const;
+
     std::vector<Field> toFields() const override;
 };
 

--- a/firmware/src/scheduler.cpp
+++ b/firmware/src/scheduler.cpp
@@ -88,10 +88,6 @@ void Scheduler::resetFiredGuards(int day) {
         fs = -1;
 }
 
-bool Scheduler::isRobotIdle(const RobotState& state) const {
-    return state.uiState == "UIMGR_STATE_IDLE" || state.uiState == "UIMGR_STATE_STANDBY";
-}
-
 bool Scheduler::isActionDue(int hour, int minute, int nowMins, int lastFiredMins, int& outSchedMins) {
     outSchedMins = hour * 60 + minute;
     int elapsed = nowMins - outSchedMins;
@@ -139,12 +135,14 @@ bool Scheduler::handleScheduledCleaning(const Settings& s, int day, int nowMins)
                 return;
             }
 
-            if (!isRobotIdle(state)) {
-                LOG("SCHED", "Robot busy (%s), skipping slot %s", state.uiState.c_str(), slotStr.c_str());
+            if (!state.isIdle()) {
+                LOG("SCHED", "Robot busy (%s / %s), skipping slot %s", state.uiState.c_str(), state.robotState.c_str(),
+                    slotStr.c_str());
                 dataLogger.logGenericEvent("scheduler_skipped", {{"day", String(day), FIELD_INT},
                                                                  {"slot", slotStr, FIELD_STRING},
                                                                  {"reason", "busy", FIELD_STRING},
-                                                                 {"state", state.uiState, FIELD_STRING}});
+                                                                 {"state", state.uiState, FIELD_STRING},
+                                                                 {"robotState", state.robotState, FIELD_STRING}});
                 firedSlots[si] = schedMins;
                 return;
             }
@@ -193,7 +191,7 @@ void Scheduler::handlePendingCleanAfterRestart() {
         if (!ok)
             return;
 
-        if (!isRobotIdle(state))
+        if (!state.isIdle())
             return;
 
         LOG("SCHED", "Robot ready after restart, triggering clean (day=%d slot=%d)", pendingCleanDay, pendingCleanSlot);
@@ -255,12 +253,14 @@ void Scheduler::handleAutoRestart(const Settings& s, int day, int nowMins) {
             return;
         }
 
-        if (!isRobotIdle(state)) {
-            LOG("SCHED", "Robot busy (%s), skipping auto restart %s", state.uiState.c_str(), slotStr.c_str());
+        if (!state.isIdle()) {
+            LOG("SCHED", "Robot busy (%s / %s), skipping auto restart %s", state.uiState.c_str(),
+                state.robotState.c_str(), slotStr.c_str());
             dataLogger.logGenericEvent("auto_restart_skipped", {{"day", String(day), FIELD_INT},
                                                                 {"slot", slotStr, FIELD_STRING},
                                                                 {"reason", "busy", FIELD_STRING},
-                                                                {"state", state.uiState, FIELD_STRING}});
+                                                                {"state", state.uiState, FIELD_STRING},
+                                                                {"robotState", state.robotState, FIELD_STRING}});
             firedAutoRestart = schedMins;
             return;
         }

--- a/firmware/src/scheduler.h
+++ b/firmware/src/scheduler.h
@@ -53,7 +53,6 @@ private:
     // Convert C library tm_wday (Sun=0..Sat=6) to our index (Mon=0..Sun=6)
     static int toSchedDay(int tmWday);
     void resetFiredGuards(int day);
-    bool isRobotIdle(const RobotState& state) const;
     bool handleScheduledCleaning(const Settings& s, int day, int nowMins);
     void handleAutoRestart(const Settings& s, int day, int nowMins);
     void handlePendingCleanAfterRestart();


### PR DESCRIPTION
## Problem

Scheduled cleaning never started on my Botvac D6 Connected (robot firmware 4.5.3.189, OpenNeato 0.15), while the manual HOUSE button worked every time.

The scheduler decides whether the robot is idle from `uiState` alone (`UIMGR_STATE_IDLE` / `UIMGR_STATE_STANDBY`). On my robot `GetState` reports:

```
Current UI State is: UIMGR_STATE_STARTHOUSECLEANING
Current Robot State is: ST_C_Standby
```

while docked, charged and idle, hours after the last clean. The UI manager got stuck in `STARTHOUSECLEANING` after a clean that raised `UI_ALERT_PM_LOAD_FAIL` (persistent map failed to load), and never returned to `STANDBY`. Every scheduled slot was therefore logged as "Robot busy" and skipped. Because log level defaults to off there was nothing in the logs to point at this.

## Fix

- Add `RobotState::isIdle()`. When the robot reports a robot state (4.5.3+) it is used as the source of truth: idle is `ST_C_Standby`, `ST_C_Idle` or `ST_M2_Charging_StdBy`. On older firmware with no robot state line it falls back to the existing `uiState` check, so behaviour there is unchanged.
- Scheduler uses `isIdle()` for scheduled cleans, clean-after-restart and auto restart.
- The "busy" skip log and data-logger event now include `robotState` so this is diagnosable in future.
- Short note in `docs/neato-serial-protocol.md` about the stuck UI state.

`notification_manager.cpp` has the same `uiState`-only idle check for the "Cleaning done" notification. I left it alone to keep this PR focused, happy to switch it to the shared helper if you would like.

## Testing

- `pio run -e c3-debug`, `pio run -e c3-release`, `scripts/check_format.py`, `pio check -e c3-debug` (no new findings).
- Flashed to the D6 over OTA and set a one-off slot two minutes ahead with `restartBeforeClean` enabled. Observed via `/api/state`: `STARTHOUSECLEANING / ST_C_Standby` -> restart issued at the slot time -> back as `IDLE / ST_C_Standby` -> `HOUSECLEANINGRUNNING / ST_F2_PartialMapManagement`. The clean started on schedule for the first time, and the restart also cleared the stuck UI state and the persistent map alert.

Thanks for the project, it has given this robot a second life.
