### PR TITLE
feat: allow trusted origins to read cleaning maps

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -147,6 +147,7 @@ enum CommandStatus {
 #define NVS_KEY_WIFI_TX_POWER "wifi_tx_pwr"
 #define NVS_KEY_UART_TX_PIN "uart_tx_pin"
 #define NVS_KEY_UART_RX_PIN "uart_rx_pin"
+#define NVS_KEY_HISTORY_CORS_ORIGIN "hist_origin"
 // NVS keys — Cleaning
 #define NVS_KEY_NAV_MODE "nav_mode" // Navigation mode: "Normal", "Gentle", "Deep", "Quick"
 // NVS keys — Manual clean

--- a/firmware/src/settings_manager.cpp
+++ b/firmware/src/settings_manager.cpp
@@ -59,6 +59,7 @@ void SettingsManager::load() {
     current.wifiTxPower = prefs.getInt(NVS_KEY_WIFI_TX_POWER, WIFI_DEFAULT_TX_POWER);
     current.uartTxPin = prefs.getInt(NVS_KEY_UART_TX_PIN, NEATO_DEFAULT_TX_PIN);
     current.uartRxPin = prefs.getInt(NVS_KEY_UART_RX_PIN, NEATO_DEFAULT_RX_PIN);
+    current.historyCorsOrigin = prefs.getString(NVS_KEY_HISTORY_CORS_ORIGIN, "");
     current.navMode = prefs.getString(NVS_KEY_NAV_MODE, "Normal");
     current.stallThreshold = prefs.getInt(NVS_KEY_MC_STALL_THR, MANUAL_STALL_LOAD_PCT);
     current.brushRpm = prefs.getInt(NVS_KEY_MC_BRUSH_RPM, MANUAL_BRUSH_RPM);
@@ -94,6 +95,7 @@ void SettingsManager::save() {
     prefs.putInt(NVS_KEY_WIFI_TX_POWER, current.wifiTxPower);
     prefs.putInt(NVS_KEY_UART_TX_PIN, current.uartTxPin);
     prefs.putInt(NVS_KEY_UART_RX_PIN, current.uartRxPin);
+    prefs.putString(NVS_KEY_HISTORY_CORS_ORIGIN, current.historyCorsOrigin);
     prefs.putString(NVS_KEY_NAV_MODE, current.navMode);
     prefs.putInt(NVS_KEY_MC_STALL_THR, current.stallThreshold);
     prefs.putInt(NVS_KEY_MC_BRUSH_RPM, current.brushRpm);
@@ -225,6 +227,25 @@ ApplyResult SettingsManager::apply(const String& json) {
         changed = true;
         needReboot = true;
         LOG("SETTINGS", "UART RX pin -> GPIO%d (reboot required)", current.uartRxPin);
+    }
+
+    if (incoming.historyCorsOrigin != current.historyCorsOrigin) {
+        String origin = incoming.historyCorsOrigin;
+        origin.trim();
+        bool valid = origin.isEmpty() || origin.length() <= 128;
+        if (!origin.isEmpty()) {
+            int hostStart = origin.indexOf("://");
+            bool hasScheme = origin.startsWith("http://") || origin.startsWith("https://");
+            bool hasPath = hostStart < 0 || origin.indexOf("/", hostStart + 3) >= 0;
+            bool unsafeChars = origin.indexOf("*") >= 0 || origin.indexOf("\r") >= 0 || origin.indexOf("\n") >= 0;
+            valid = valid && hasScheme && !hasPath && !unsafeChars;
+        }
+        if (!valid)
+            return APPLY_INVALID;
+        current.historyCorsOrigin = origin;
+        changed = true;
+        LOG("SETTINGS", "History CORS origin -> %s",
+            current.historyCorsOrigin.isEmpty() ? "(disabled)" : current.historyCorsOrigin.c_str());
     }
 
     // Cleaning — navigation mode (sent to robot before each house clean)
@@ -378,6 +399,7 @@ std::vector<Field> Settings::toFields() const {
             {"wifiTxPower", String(wifiTxPower), FIELD_INT},
             {"uartTxPin", String(uartTxPin), FIELD_INT},
             {"uartRxPin", String(uartRxPin), FIELD_INT},
+            {"historyCorsOrigin", historyCorsOrigin, FIELD_STRING},
             {"maxGpioPin", String(MAX_GPIO_PIN), FIELD_INT},
             {"navMode", navMode, FIELD_STRING},
             {"stallThreshold", String(stallThreshold), FIELD_INT},
@@ -440,6 +462,10 @@ bool Settings::fromFields(const std::vector<Field>& fields) {
     }
     if ((f = findField(fields, "uartRxPin")) && f->type == FIELD_INT) {
         uartRxPin = f->value.toInt();
+        applied = true;
+    }
+    if ((f = findField(fields, "historyCorsOrigin")) && f->type == FIELD_STRING) {
+        historyCorsOrigin = f->value;
         applied = true;
     }
     if ((f = findField(fields, "navMode")) && f->type == FIELD_STRING) {

--- a/firmware/src/settings_manager.h
+++ b/firmware/src/settings_manager.h
@@ -27,6 +27,7 @@ struct Settings : public JsonSerializable {
     int wifiTxPower = WIFI_DEFAULT_TX_POWER; // 0.25 dBm units (34 = 8.5 dBm)
     int uartTxPin = NEATO_DEFAULT_TX_PIN; // ESP GPIO -> Robot RX
     int uartRxPin = NEATO_DEFAULT_RX_PIN; // ESP GPIO <- Robot TX
+    String historyCorsOrigin; // Exact trusted browser origin; empty disables cross-origin map reads
     // House cleaning — sent to robot before each house clean starts
     String navMode = "Normal"; // Navigation mode: "Normal", "Gentle", "Deep", "Quick"
     // Manual clean motor settings

--- a/firmware/src/web_server.cpp
+++ b/firmware/src/web_server.cpp
@@ -180,6 +180,17 @@ static String logListJson(const std::vector<LogFileInfo>& files) {
     return json;
 }
 
+static void addHistoryCors(AsyncWebServerRequest *request, AsyncWebServerResponse *response,
+                           const String& allowedOrigin) {
+    if (allowedOrigin.isEmpty() || !request->hasHeader("Origin"))
+        return;
+    String requestOrigin = request->getHeader("Origin")->value();
+    if (requestOrigin != allowedOrigin)
+        return;
+    response->addHeader("Access-Control-Allow-Origin", allowedOrigin);
+    response->addHeader("Vary", "Origin");
+}
+
 void WebServer::registerLogRoutes() {
 
     // GET /api/logs[/filename] — list logs or download a specific file
@@ -415,7 +426,9 @@ void WebServer::registerMapRoutes() {
             }
             json += "]";
             logger.logRequest(HTTP_GET, "/api/history", 200, millis() - startMs);
-            request->send(200, "application/json", json);
+            AsyncWebServerResponse *response = request->beginResponse(200, "application/json", json);
+            addHistoryCors(request, response, settingsMgr.get().historyCorsOrigin);
+            request->send(response);
             return;
         }
 
@@ -434,6 +447,7 @@ void WebServer::registerMapRoutes() {
                 [reader](uint8_t *buffer, size_t maxLen, size_t) -> size_t { return reader->read(buffer, maxLen); });
 
         response->addHeader("Content-Disposition", "attachment; filename=\"" + downloadName(suffix) + "\"");
+        addHistoryCors(request, response, settingsMgr.get().historyCorsOrigin);
 
         request->send(response);
     });

--- a/frontend/api/openapi.yaml
+++ b/frontend/api/openapi.yaml
@@ -796,6 +796,7 @@ paths:
       tags:
         - History
       summary: List all cleaning session files with embedded session and summary metadata
+      description: Cross-origin browser access is allowed only when the request Origin exactly matches historyCorsOrigin.
       responses:
         "200":
           description: OK
@@ -817,6 +818,7 @@ paths:
       tags:
         - History
       summary: Download a single session file (transparently decompressed)
+      description: Cross-origin browser access is allowed only when the request Origin exactly matches historyCorsOrigin.
       parameters:
         - name: filename
           in: path
@@ -1404,6 +1406,10 @@ components:
         apFallbackOnDisconnect:
           type: boolean
           description: Bring up the fallback AP automatically when STA drops
+        historyCorsOrigin:
+          type: string
+          description: Exact trusted browser origin allowed to read cleaning history (empty disables CORS)
+          example: "https://homeassistant.example.com"
         syslogEnabled:
           type: boolean
           description: When on, logs go to UDP syslog instead of flash


### PR DESCRIPTION
Summary

This PR adds secure, optional cross-origin access to OpenNeato cleaning-history maps. It enables browser-based clients such as Home Assistant Lovelace cards to read cleaning sessions directly from the ESP API.

Changes

Adds a persistent historyCorsOrigin setting

Cross-origin access remains disabled by default

Allows exactly one trusted HTTP or HTTPS origin

Rejects wildcards, paths, trailing slashes, and invalid header characters

Applies CORS only to:

GET /api/history

GET /api/history/{filename}


Importing and deleting history remain same-origin

Documents the new setting in the OpenAPI specification


Security

This PR deliberately does not use Access-Control-Allow-Origin: *.

Cleaning maps may reveal household layout and activity information. The CORS header is therefore returned only when the requesting origin exactly matches the configured historyCorsOrigin.

Write operations are never exposed cross-origin.

Configuration example

Set the trusted Home Assistant origin through PUT /api/settings:

{
  "historyCorsOrigin": "http://homeassistant.local:8123"
}

Only the scheme, hostname or IP address, and optional port are allowed. Do not include a path or trailing slash.

To disable cross-origin access again:

{
  "historyCorsOrigin": ""
}

Motivation

This provides the firmware/API prerequisite for browser-based cleaning-map clients and contributes to issue #37.

The Home Assistant integration may alternatively proxy map data through its backend. This setting is intended for clients that explicitly need direct browser access to the ESP API.

Validation

npm run check

OpenAPI type generation

Firmware/API route parity check

tsc --noEmit

git diff --check


A firmware build could not be run locally because Python and PlatformIO were unavailable. The repository CI should run the firmware build and static checks.